### PR TITLE
Exclude system events from unread counts

### DIFF
--- a/Sources/IMsgCore/MessageStore+Chats.swift
+++ b/Sources/IMsgCore/MessageStore+Chats.swift
@@ -21,7 +21,7 @@ private struct ListChatsQuery {
 
   init(limit: Int, offset: Int = 0, unreadOnly: Bool, schema: MessageStoreSchema) {
     let routing = ChatRoutingSelection(schema: schema)
-    let unreadSelection = UnreadChatSelection(enabled: unreadOnly)
+    let unreadSelection = UnreadChatSelection(enabled: unreadOnly, schema: schema)
     if schema.hasChatMessageJoinMessageDateColumn {
       self.sql = """
         SELECT c.ROWID AS chat_rowid, IFNULL(c.display_name, c.chat_identifier) AS name,
@@ -61,17 +61,21 @@ private struct ListChatsQuery {
 private struct UnreadChatSelection {
   let joinClause: String
 
-  init(enabled: Bool) {
+  init(enabled: Bool, schema: MessageStoreSchema) {
     guard enabled else {
       self.joinClause = ""
       return
     }
+    let userMessageFilter =
+      schema.hasItemTypeColumn
+      ? " AND IFNULL(m_unread.item_type, 0) = 0"
+      : ""
     self.joinClause = """
       JOIN (
         SELECT DISTINCT cmj_unread.chat_id
         FROM chat_message_join cmj_unread
         JOIN message m_unread ON m_unread.ROWID = cmj_unread.message_id
-        WHERE m_unread.is_from_me = 0 AND m_unread.is_read = 0
+        WHERE m_unread.is_from_me = 0 AND m_unread.is_read = 0\(userMessageFilter)
       ) unread ON unread.chat_id = c.ROWID
       """
   }
@@ -86,6 +90,10 @@ private struct UnreadMessagesQuery {
     let selection = MessageRowSelection(store: store, includeChatID: true)
     self.selection = selection
     let placeholders = Array(repeating: "?", count: chatIDs.count).joined(separator: ", ")
+    let userMessageFilter =
+      store.schema.hasItemTypeColumn
+      ? " AND IFNULL(m.item_type, 0) = 0"
+      : ""
     self.sql = """
       SELECT \(selection.selectList)
       FROM message m
@@ -93,7 +101,7 @@ private struct UnreadMessagesQuery {
       LEFT JOIN handle h ON m.handle_id = h.ROWID
       WHERE cmj.chat_id IN (\(placeholders))
         AND m.is_from_me = 0
-        AND m.is_read = 0
+        AND m.is_read = 0\(userMessageFilter)
       ORDER BY cmj.chat_id, m.ROWID
       """
     self.bindings = chatIDs.map { $0 as Binding? }

--- a/Sources/IMsgCore/MessageStoreSchema.swift
+++ b/Sources/IMsgCore/MessageStoreSchema.swift
@@ -20,6 +20,7 @@ struct MessageStoreSchema: Sendable {
   let hasChatLastAddressedHandleColumn: Bool
   let hasIsReadColumn: Bool
   let hasDateReadColumn: Bool
+  let hasItemTypeColumn: Bool
 
   init(connection: Connection) throws {
     let messageColumns = try MessageStore.tableColumns(connection: connection, table: "message")
@@ -50,6 +51,7 @@ struct MessageStoreSchema: Sendable {
     self.hasChatLastAddressedHandleColumn = chatColumns.contains("last_addressed_handle")
     self.hasIsReadColumn = messageColumns.contains("is_read")
     self.hasDateReadColumn = messageColumns.contains("date_read")
+    self.hasItemTypeColumn = messageColumns.contains("item_type")
   }
 
   init(
@@ -70,7 +72,8 @@ struct MessageStoreSchema: Sendable {
     hasChatAccountLoginColumn: Bool? = nil,
     hasChatLastAddressedHandleColumn: Bool? = nil,
     hasIsReadColumn: Bool? = nil,
-    hasDateReadColumn: Bool? = nil
+    hasDateReadColumn: Bool? = nil,
+    hasItemTypeColumn: Bool? = nil
   ) {
     self.hasAttributedBody = hasAttributedBody ?? base.hasAttributedBody
     self.hasReactionColumns = hasReactionColumns ?? base.hasReactionColumns
@@ -96,5 +99,6 @@ struct MessageStoreSchema: Sendable {
       hasChatLastAddressedHandleColumn ?? base.hasChatLastAddressedHandleColumn
     self.hasIsReadColumn = hasIsReadColumn ?? base.hasIsReadColumn
     self.hasDateReadColumn = hasDateReadColumn ?? base.hasDateReadColumn
+    self.hasItemTypeColumn = hasItemTypeColumn ?? base.hasItemTypeColumn
   }
 }

--- a/Tests/IMsgCoreTests/MessageStoreSystemEventUnreadTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreSystemEventUnreadTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import SQLite
+import Testing
+
+@testable import IMsgCore
+
+@Test
+func listChatsIgnoresUnreadSystemEvents() throws {
+  let db = try Connection(.inMemory)
+  try MessageDatabaseFixture.createSchema(
+    db,
+    options: MessageDatabaseFixture.SchemaOptions(includeReadState: true)
+  )
+  try db.execute("ALTER TABLE message ADD COLUMN item_type INTEGER;")
+
+  let now = Date()
+  try db.run(
+    """
+    INSERT INTO chat(ROWID, chat_identifier, guid, display_name, service_name)
+    VALUES (1, '+111', 'iMessage;-;+111', 'Ghost Rows', 'iMessage')
+    """
+  )
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+111')")
+  try db.run(
+    """
+    INSERT INTO message(
+      ROWID, handle_id, text, date, is_from_me, service, is_read, date_read, item_type
+    )
+    VALUES
+      (1, 1, NULL, ?, 0, 'iMessage', 0, 0, 4),
+      (2, 1, '', ?, 0, 'iMessage', 0, 0, 2),
+      (3, 1, 'visible unread', ?, 0, 'iMessage', 0, 0, 0),
+      (4, 1, '', ?, 0, 'iMessage', 0, 0, 0),
+      (5, 1, '', ?, 0, 'iMessage', 0, 0, 3)
+    """,
+    TestDatabase.appleEpoch(now.addingTimeInterval(-4)),
+    TestDatabase.appleEpoch(now.addingTimeInterval(-3)),
+    TestDatabase.appleEpoch(now.addingTimeInterval(-2)),
+    TestDatabase.appleEpoch(now.addingTimeInterval(-1)),
+    TestDatabase.appleEpoch(now)
+  )
+  try db.run(
+    """
+    INSERT INTO chat_message_join(chat_id, message_id)
+    VALUES (1, 1), (1, 2), (1, 3), (1, 4), (1, 5)
+    """
+  )
+  try db.run(
+    """
+    INSERT INTO attachment(ROWID, filename, transfer_name)
+    VALUES
+      (1, 'photo.heic', 'photo.heic'),
+      (2, 'group-photo.heic', 'GroupPhotoImage')
+    """
+  )
+  try db.run(
+    """
+    INSERT INTO message_attachment_join(message_id, attachment_id)
+    VALUES (4, 1), (5, 2)
+    """
+  )
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  #expect(try store.listChats(limit: 1).first?.unreadCount == 2)
+}
+
+@Test
+func listChatsUnreadOnlySkipsChatsWithOnlySystemEvents() throws {
+  let db = try Connection(.inMemory)
+  try MessageDatabaseFixture.createSchema(
+    db,
+    options: MessageDatabaseFixture.SchemaOptions(includeReadState: true)
+  )
+  try db.execute("ALTER TABLE message ADD COLUMN item_type INTEGER;")
+
+  let now = Date()
+  try db.run(
+    """
+    INSERT INTO chat(ROWID, chat_identifier, guid, display_name, service_name)
+    VALUES
+      (1, '+111', 'iMessage;-;+111', 'Older Unread', 'iMessage'),
+      (2, '+222', 'iMessage;-;+222', 'Newer Ghost', 'iMessage')
+    """
+  )
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+111'), (2, '+222')")
+  try db.run(
+    """
+    INSERT INTO message(
+      ROWID, handle_id, text, date, is_from_me, service, is_read, date_read, item_type
+    )
+    VALUES
+      (1, 1, 'actually unread', ?, 0, 'iMessage', 0, 0, 0),
+      (2, 2, '', ?, 0, 'iMessage', 0, 0, 4),
+      (3, 2, '', ?, 0, 'iMessage', 0, 0, 3)
+    """,
+    TestDatabase.appleEpoch(now.addingTimeInterval(-60)),
+    TestDatabase.appleEpoch(now.addingTimeInterval(-1)),
+    TestDatabase.appleEpoch(now)
+  )
+  try db.run(
+    "INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1), (2, 2), (2, 3)"
+  )
+  try db.run(
+    """
+    INSERT INTO attachment(ROWID, filename, transfer_name)
+    VALUES (1, 'group-photo.heic', 'GroupPhotoImage')
+    """
+  )
+  try db.run("INSERT INTO message_attachment_join(message_id, attachment_id) VALUES (3, 1)")
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let chats = try store.listChats(limit: 1, unreadOnly: true)
+  #expect(chats.map(\.id) == [1])
+  #expect(chats.first?.unreadCount == 1)
+}

--- a/docs/chats.md
+++ b/docs/chats.md
@@ -46,7 +46,7 @@ Objects returned by `imsg chats --json` and JSON-RPC `chats.list` include:
 | `account_id` | string | Routing diagnostic. Read-only. |
 | `account_login` | string | Routing diagnostic. Read-only. |
 | `last_addressed_handle` | string | Routing diagnostic. Read-only. |
-| `unread_count` | int | Count of unread inbound messages in the chat. Omitted on older database schemas without read state. |
+| `unread_count` | int | Count of unread inbound user messages in the chat. System events are excluded. Omitted on older database schemas without read state. |
 
 ## Routing identifiers — which one to use
 

--- a/docs/json.md
+++ b/docs/json.md
@@ -32,7 +32,7 @@ Returned by `imsg chats --json` and JSON-RPC `chats.list`.
 | `account_id` | string | Routing diagnostic. Read-only. |
 | `account_login` | string | Routing diagnostic. Read-only. |
 | `last_addressed_handle` | string | Routing diagnostic. Read-only. |
-| `unread_count` | int | Count of unread inbound messages in the chat. Omitted on older database schemas without read state. |
+| `unread_count` | int | Count of unread inbound user messages in the chat. System events are excluded. Omitted on older database schemas without read state. |
 
 ## Message
 


### PR DESCRIPTION
## Summary

- exclude system-event rows from chat unread counts and `--unread-only` selection
- detect the `message.item_type` column so older Messages database schemas keep working
- cover both count calculation and unread-chat pagination with regression tests
- clarify the `unread_count` contract in the chat and JSON documentation

## Root cause

Messages can leave inbound system-event rows, including location-sharing status events, with `is_read = 0`. The existing query counted every inbound unread row, so those events could make a chat appear unread indefinitely even when it had no unread user messages.

The updated query counts rows with `item_type = 0`, treating a missing value as a normal message. It only adds that predicate when the schema has the column.

## Validation

- `swift test --filter listChatsIgnoresUnreadSystemEvents`
- `swift test --filter listChatsUnreadOnlySkipsChatsWithOnlySystemEvents`
- `PATH=/opt/homebrew/bin:$PATH make lint` (`0` serious violations)
- `make build`

The full suite runs 667 tests on this host. The two new tests pass. Three unrelated RPC bridge-send tests also fail on unmodified `origin/main` because the live installed bridge does not match the test process; the PR produces the same 13 assertion failures and no additional failures.

## Real Messages database verification

I ran the base and patched release binaries against the same live `~/Library/Messages/chat.db` on macOS 26.5.2, arm64. Chat identifiers are replaced with descriptive labels below.

The event-only control has eight inbound rows where `is_read = 0`. Every row has `item_type = 4`, and none has text, an attributed body, an attachment, a balloon payload, or an associated message:

```text
unread_rows  min_item_type  max_item_type  user_payload_rows
-----------  -------------  -------------  -----------------
8            4              4              0
```

Unread physical rows across the database show that normal messages use `item_type = 0`. Types 2 and 4 have no user-content fields populated:

```text
item_type  unread_rows  text_rows  attributed_rows  attachment_rows  balloon_rows  associated_rows
---------  -----------  ---------  ---------------  ---------------  ------------  ---------------
0          16           0          16               0                0             0
1           2           0           0               0                0             0
2          17           0           0               0                0             0
3          10           0           0               4                0             0
4          88           0           0               0                0             0
5           1           0           0               0                0             0
6           2           0           0               0                0             0
```

The four type-3 rows with attachments are not photo messages. All four are group-photo metadata events with `group_action_type = 1` and `transfer_name = GroupPhotoImage`. Across this database, all 19,380 ordinary attachment rows use `item_type = 0`:

```text
item_type  group_action_type  attachment_rows  group_photo_rows  other_attachment_rows
---------  -----------------  ---------------  ----------------  ---------------------
0          0                  19380            0                 19380
3          1                  4                4                 0
```

The regression fixtures mirror both cases. An inbound type-0 photo remains counted, while an attached type-3 `GroupPhotoImage` event does not affect the count or unread-only selection.

Finally, `imsg chats --unread-only --limit 100000 --json` was reduced to redacted aggregate values. The normal-message control remains unread while the event-only chat disappears:

```text
base 0.13.5
unread_chat_count:     41
total_unread_messages: 130
event_only_chat:        8
normal_message_control: 1

patched 0.13.5
unread_chat_count:     14
total_unread_messages: 14
event_only_chat:        0
normal_message_control: 1
```
