### PR TITLE
fix(cli): do not block watch/search on undetermined Contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Headless `imsg watch` and `imsg search` no longer block on an undetermined Contacts prompt (same TTY policy as `imsg rpc`; `imsg send` still prompts)
+
 ## 0.14.1 - 2026-08-11
 
 **Highlight:** search now finds messages whose text lives only in the rich-text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Let headless `watch` and `search` start without waiting for an undetermined Contacts permission prompt while preserving interactive prompting (#238, thanks @SebTardif).
+
 ## 0.14.1 - 2026-08-11
 
 **Highlight:** search now finds messages whose text lives only in the rich-text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Fixes
-
-- Headless `imsg watch` and `imsg search` no longer block on an undetermined Contacts prompt (same TTY policy as `imsg rpc`; `imsg send` still prompts)
-
 ## 0.14.1 - 2026-08-11
 
 **Highlight:** search now finds messages whose text lives only in the rich-text

--- a/Sources/IMsgCore/ContactResolver.swift
+++ b/Sources/IMsgCore/ContactResolver.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+#if canImport(Darwin)
+  import Darwin
+#elseif canImport(Glibc)
+  import Glibc
+#endif
+
 #if os(macOS)
   @preconcurrency import Contacts
 #endif
@@ -37,6 +43,18 @@ public final class NoOpContactResolver: ContactResolving, Sendable {
 public enum ContactsAccessPolicy: Sendable {
   case requestIfNeeded
   case skipIfNotDetermined
+
+  /// Headless stdin (LaunchAgent, pipes, automation) must not block on a
+  /// Contacts prompt that will never resolve while authorization remains
+  /// `.notDetermined`. Interactive terminals keep the prompt-capable path.
+  public static func forStdin(isTTY: Bool) -> ContactsAccessPolicy {
+    isTTY ? .requestIfNeeded : .skipIfNotDetermined
+  }
+
+  /// Whether the current process stdin is an interactive TTY.
+  public static var stdinIsTTY: Bool {
+    isatty(STDIN_FILENO) != 0
+  }
 }
 
 /// A process-owned Contacts catalog. Reads stay synchronous for existing callers, while the

--- a/Sources/imsg/Commands/BridgeIntroCommands.swift
+++ b/Sources/imsg/Commands/BridgeIntroCommands.swift
@@ -5,6 +5,11 @@ import IMsgCore
 // MARK: - search
 
 enum SearchCommand {
+  /// Same TTY rule as RPC: headless stdin must not prompt for Contacts.
+  static func contactsAccessPolicy(stdinIsTTY: Bool) -> ContactsAccessPolicy {
+    .forStdin(isTTY: stdinIsTTY)
+  }
+
   static let spec = CommandSpec(
     name: "search",
     abstract: "Search local Messages history",
@@ -30,7 +35,9 @@ enum SearchCommand {
     values: ParsedValues,
     runtime: RuntimeOptions,
     contactResolverFactory: @escaping () async -> any ContactResolving = {
-      await ContactResolver.create()
+      await ContactResolver.create(
+        accessPolicy: contactsAccessPolicy(stdinIsTTY: ContactsAccessPolicy.stdinIsTTY)
+      )
     }
   ) async throws {
     guard let q = values.option("query"), !q.isEmpty else {

--- a/Sources/imsg/Commands/RpcCommand.swift
+++ b/Sources/imsg/Commands/RpcCommand.swift
@@ -2,12 +2,6 @@ import Commander
 import Foundation
 import IMsgCore
 
-#if canImport(Darwin)
-  import Darwin
-#elseif canImport(Glibc)
-  import Glibc
-#endif
-
 enum RpcCommand {
   /// Contacts policy for RPC startup.
   ///
@@ -16,12 +10,12 @@ enum RpcCommand {
   /// remains `.notDetermined`. Interactive terminals keep the prompt-capable
   /// path so Contacts-backed name resolution still works.
   static var startupContactsAccessPolicy: ContactsAccessPolicy {
-    contactsAccessPolicy(stdinIsTTY: isatty(STDIN_FILENO) != 0)
+    contactsAccessPolicy(stdinIsTTY: ContactsAccessPolicy.stdinIsTTY)
   }
 
   /// Pure policy helper for tests and callers that already know interactivity.
   static func contactsAccessPolicy(stdinIsTTY: Bool) -> ContactsAccessPolicy {
-    stdinIsTTY ? .requestIfNeeded : .skipIfNotDetermined
+    .forStdin(isTTY: stdinIsTTY)
   }
 
   static let spec = CommandSpec(

--- a/Sources/imsg/Commands/WatchCommand.swift
+++ b/Sources/imsg/Commands/WatchCommand.swift
@@ -3,6 +3,11 @@ import Foundation
 import IMsgCore
 
 enum WatchCommand {
+  /// Same TTY rule as RPC: headless stdin must not prompt for Contacts.
+  static func contactsAccessPolicy(stdinIsTTY: Bool) -> ContactsAccessPolicy {
+    .forStdin(isTTY: stdinIsTTY)
+  }
+
   static let spec = CommandSpec(
     name: "watch",
     abstract: "Stream incoming messages",
@@ -55,7 +60,9 @@ enum WatchCommand {
     runtime: RuntimeOptions,
     storeFactory: @escaping (String) throws -> MessageStore = { try MessageStore(path: $0) },
     contactResolverFactory: @escaping () async -> any ContactResolving = {
-      await ContactResolver.create()
+      await ContactResolver.create(
+        accessPolicy: contactsAccessPolicy(stdinIsTTY: ContactsAccessPolicy.stdinIsTTY)
+      )
     },
     streamProvider:
       @escaping (

--- a/Tests/imsgTests/RpcCommandContactsPolicyTests.swift
+++ b/Tests/imsgTests/RpcCommandContactsPolicyTests.swift
@@ -4,6 +4,19 @@ import Testing
 
 @testable import imsg
 
+@Suite("Shared Contacts stdin policy")
+struct ContactsAccessPolicyStdinTests {
+  @Test("headless stdin uses skipIfNotDetermined")
+  func headlessSkipsUndetermined() {
+    #expect(ContactsAccessPolicy.forStdin(isTTY: false) == .skipIfNotDetermined)
+  }
+
+  @Test("interactive stdin keeps requestIfNeeded")
+  func interactiveRequestsIfNeeded() {
+    #expect(ContactsAccessPolicy.forStdin(isTTY: true) == .requestIfNeeded)
+  }
+}
+
 @Suite("RpcCommand Contacts policy")
 struct RpcCommandContactsPolicyTests {
   @Test("headless stdin uses skipIfNotDetermined")
@@ -14,5 +27,31 @@ struct RpcCommandContactsPolicyTests {
   @Test("interactive stdin keeps requestIfNeeded")
   func interactiveRequestsIfNeeded() {
     #expect(RpcCommand.contactsAccessPolicy(stdinIsTTY: true) == .requestIfNeeded)
+  }
+}
+
+@Suite("WatchCommand Contacts policy")
+struct WatchCommandContactsPolicyTests {
+  @Test("watch factory uses skipIfNotDetermined when stdin is not a TTY")
+  func headlessFactorySkipsUndetermined() {
+    #expect(WatchCommand.contactsAccessPolicy(stdinIsTTY: false) == .skipIfNotDetermined)
+  }
+
+  @Test("watch factory keeps requestIfNeeded on interactive stdin")
+  func interactiveFactoryRequestsIfNeeded() {
+    #expect(WatchCommand.contactsAccessPolicy(stdinIsTTY: true) == .requestIfNeeded)
+  }
+}
+
+@Suite("SearchCommand Contacts policy")
+struct SearchCommandContactsPolicyTests {
+  @Test("search factory uses skipIfNotDetermined when stdin is not a TTY")
+  func headlessFactorySkipsUndetermined() {
+    #expect(SearchCommand.contactsAccessPolicy(stdinIsTTY: false) == .skipIfNotDetermined)
+  }
+
+  @Test("search factory keeps requestIfNeeded on interactive stdin")
+  func interactiveFactoryRequestsIfNeeded() {
+    #expect(SearchCommand.contactsAccessPolicy(stdinIsTTY: true) == .requestIfNeeded)
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Merged [#187](https://github.com/openclaw/imsg/pull/187) (issue [#186](https://github.com/openclaw/imsg/issues/186)) fixed headless `imsg rpc` so Contacts `.notDetermined` does not block forever. CLI `watch` and `search` still called `ContactResolver.create()` with the default `.requestIfNeeded`:

```swift
// WatchCommand.run / SearchCommand.run default factory
await ContactResolver.create()
```

When Contacts authorization is still `.notDetermined`, that awaits `CNContactStore.requestAccess`. In a headless (non-TTY) process the prompt can stay pending, so `imsg watch` and `imsg search` hang before they emit output. `chats` and `history` already use `.skipIfNotDetermined` ([#136](https://github.com/openclaw/imsg/pull/136)). `imsg send` still prompts, because name targets need Contacts.

## Evidence

### Prior art (same repo)

- [#136](https://github.com/openclaw/imsg/pull/136) added `ContactsAccessPolicy.skipIfNotDetermined` for `imsg chats` and `imsg history`.
- [#187](https://github.com/openclaw/imsg/pull/187) applied a TTY-aware rule to `imsg rpc` (`stdin` not a TTY -> skip; interactive TTY -> request). `watch` and `search` were left on the default.
- `ContactResolver.create(accessPolicy: .skipIfNotDetermined)` already returns `NoOpContactResolver(contactsUnavailable: true)` without calling `requestAccess`.

### Fix

The TTY rule now lives once on `ContactsAccessPolicy.forStdin(isTTY:)`. RPC, watch, and search factories all use it. `imsg send` is unchanged.

### Live headless search (after fix)

Environment: macOS 26.6.1 (Build 25G76), arm64, Contacts authorization **notDetermined** (raw `0`), patched binary at commit `545aa3d`, stdin from `/dev/null` (not a TTY). Fixture Messages DB via `--db` so the command reaches `ContactResolver.create`.

```console
$ swift -e 'import Contacts; print(CNContactStore.authorizationStatus(for: .contacts).rawValue)'
0

$ ./bin/imsg search --query hello --limit 5 --db /tmp/imsg-watch-search-contacts-fixture.db < /dev/null
2026-08-15T21:17:18.121Z [recv] +15555550100: hello from fixture
process exit=0 elapsed_s=0.755
```

Search returned a fixture hit in under a second while Contacts stayed undetermined (no prompt hang). Headless `imsg watch` on the same DB stayed in its event loop (killed after 2.013s), so Contacts did not block startup.

## Real behavior proof

- **Behavior or issue addressed:** Headless `imsg watch` and `imsg search` must not block on an undetermined Contacts permission prompt. Interactive TTY still uses the prompt-capable path. `imsg send` still prompts.
- **Real environment tested:** macOS 26.6.1 (Build 25G76), arm64, Contacts authorization status `notDetermined` (raw 0) on the host. Patched binary `545aa3d` at `/tmp/oc-impl-imsg-contacts/bin/imsg`. Headless non-TTY stdin (`/dev/null`). Fixture chat.db so FDA is not required and the command still runs `ContactResolver.create`.
- **Exact steps or command run after this patch:**

  ```bash
  swift -e 'import Contacts; print(CNContactStore.authorizationStatus(for: .contacts).rawValue)'
  make build ARCHES=$(uname -m)
  ./bin/imsg search --query hello --limit 5 --db /tmp/imsg-watch-search-contacts-fixture.db < /dev/null
  ```

- **Evidence after fix:** terminal output from the headless search session above: `imsg search --query hello` printed the fixture message and exited 0 in 0.755s while Contacts stayed undetermined. Headless `imsg watch` on the same DB was still running after 2.013s (Contacts did not block startup).
- **Observed result after fix:** watch and search no longer wait on `requestAccess` when stdin is not a TTY and Contacts is undetermined. Name enrichment remains optional until Contacts is already authorized (fixture used the raw handle `+15555550100`).
- **What was not tested:** Live authorized-Contacts path on this host (authorization is notDetermined, not authorized). Interactive TTY prompt path was not exercised here (policy keeps `.requestIfNeeded` for TTY). `imsg send` was not changed. Real LaunchAgent plist install was not used; proof used equivalent non-TTY stdin.

## Notes

- Sibling of [#187](https://github.com/openclaw/imsg/pull/187) / [#136](https://github.com/openclaw/imsg/pull/136)
- Changelog entry under Unreleased / Fixes
- Shared helper is `ContactsAccessPolicy.forStdin(isTTY:)` so the TTY rule is not copied in three places
