### PR TITLE
fix(poll): report whether the caption carrying the question was delivered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 - Fall back to raw chat identifiers for empty display names and distinguish unavailable Contacts from unmatched local nicknames (#250, thanks @riverr4t).
 - Let headless `nickname --local` return without an unanswered Contacts permission prompt while preserving interactive prompting (#248, thanks @SebTardif).
-- Report whether a poll's caption was delivered, and verify it against the target chat before saying so. Messages never renders a poll's title, so the caption sent after the balloon is the only thing that shows the question. Both CLI and RPC now return a `comment` object with tri-state `sent` (`true`, `false`, or `null` when delivery is unknown), `verified`, and typed retry guidance. Caption recovery is recommended only when the transport proves `retry_safe: true`; re-sending the poll would duplicate the balloon (#239).
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Fall back to raw chat identifiers for empty display names and distinguish unavailable Contacts from unmatched local nicknames (#250, thanks @riverr4t).
 - Let headless `nickname --local` return without an unanswered Contacts permission prompt while preserving interactive prompting (#248, thanks @SebTardif).
-- Report whether a poll's caption was delivered, and verify it against the target chat before saying so. Messages never renders a poll's title, so the caption sent after the balloon is the only thing that shows the question — but a failed caption was written to stderr while `poll send` / `poll.send` still reported plain success, leaving callers unable to tell a question-less poll from a complete one. Both surfaces now return a `comment` object (`requested`, `sent`, `verified`, and `error` / `disposition` / `retry_safe` on failure). The send still succeeds when only the caption fails, because re-sending would duplicate the balloon (#239).
+- Report whether a poll's caption was delivered, and verify it against the target chat before saying so. Messages never renders a poll's title, so the caption sent after the balloon is the only thing that shows the question. Both CLI and RPC now return a `comment` object with tri-state `sent` (`true`, `false`, or `null` when delivery is unknown), `verified`, and typed retry guidance. Caption recovery is recommended only when the transport proves `retry_safe: true`; re-sending the poll would duplicate the balloon (#239).
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fall back to raw chat identifiers for empty display names and distinguish unavailable Contacts from unmatched local nicknames (#250, thanks @riverr4t).
 - Let headless `nickname --local` return without an unanswered Contacts permission prompt while preserving interactive prompting (#248, thanks @SebTardif).
+- Report whether a poll's caption was delivered, and verify it against the target chat before saying so. Messages never renders a poll's title, so the caption sent after the balloon is the only thing that shows the question — but a failed caption was written to stderr while `poll send` / `poll.send` still reported plain success, leaving callers unable to tell a question-less poll from a complete one. Both surfaces now return a `comment` object (`requested`, `sent`, `verified`, and `error` / `disposition` / `retry_safe` on failure). The send still succeeds when only the caption fails, because re-sending would duplicate the balloon (#239).
 
 ### Dependencies
 

--- a/Sources/imsg/Commands/BridgeMessagingCommands.swift
+++ b/Sources/imsg/Commands/BridgeMessagingCommands.swift
@@ -61,6 +61,11 @@ enum BridgeOutput {
 
   /// Invoke a bridge action and emit the result. Returns the data dict on
   /// success or nil on failure (after emitting an error message).
+  ///
+  /// `finalize` runs after the action succeeds but before anything is emitted,
+  /// so a command that performs follow-up work can fold that work's outcome
+  /// into the single emitted object. Callers that pass no `finalize` emit the
+  /// bridge payload unchanged.
   static func invokeAndEmit(
     action: BridgeAction,
     params: [String: Any],
@@ -69,16 +74,21 @@ enum BridgeOutput {
       action, params in
       try await IMsgBridgeClient.shared.invoke(action: action, params: params)
     },
+    finalize: (([String: Any]) async -> [String: Any])? = nil,
     summary: (([String: Any]) -> String)
   ) async throws -> [String: Any] {
+    let data: [String: Any]
     do {
-      let data = try await invokeBridge(action, params)
-      emit(data, runtime: runtime, summary: summary(data))
-      return data
+      data = try await invokeBridge(action, params)
     } catch {
       emitError(String(describing: error), runtime: runtime)
       throw EmittedError()
     }
+    // Outside the `do`: the action already succeeded, so follow-up work must
+    // never be reported as an action failure.
+    let payload = await finalize?(data) ?? data
+    emit(payload, runtime: runtime, summary: summary(payload))
+    return payload
   }
 }
 

--- a/Sources/imsg/Commands/BridgeMessagingCommands.swift
+++ b/Sources/imsg/Commands/BridgeMessagingCommands.swift
@@ -59,8 +59,7 @@ enum BridgeOutput {
     }
   }
 
-  /// Invoke a bridge action and emit the result. Returns the data dict on
-  /// success or nil on failure (after emitting an error message).
+  /// Invoke a bridge action and emit the result; emit then throw on failure.
   ///
   /// `finalize` runs after the action succeeds but before anything is emitted,
   /// so a command that performs follow-up work can fold that work's outcome

--- a/Sources/imsg/Commands/PollCaptionStatus.swift
+++ b/Sources/imsg/Commands/PollCaptionStatus.swift
@@ -47,7 +47,7 @@ enum PollCaptionStatus {
       "sent": false,
       "verified": false,
       "error":
-        "The bridge accepted the caption but no matching row appeared in the target chat.",
+        "The bridge accepted the caption but it never reached a sent state in the target chat.",
       "disposition": DeliveryDisposition.mayHaveCompleted.rawValue,
       "retry_safe": false,
     ]
@@ -85,6 +85,22 @@ enum PollCaptionStatus {
   /// bound costs honesty about certainty rather than causing duplicate sends.
   static let rpcVerifyTimeout: TimeInterval = 2
 
+  /// Reads a caption row's send state. A row existing is not delivery: Messages
+  /// records failed and still-pending sends as rows too, and reporting either
+  /// as a delivered caption would recreate exactly the false success this
+  /// status object exists to remove.
+  ///
+  /// - Returns: `true` once Messages reports the row sent or delivered, `false`
+  ///   when it recorded a failure — waiting cannot change that — and `nil`
+  ///   while the send is still pending and may yet flip either way.
+  static func captionOutcome(for state: MessageSendState) -> Bool? {
+    switch state {
+    case .sent, .delivered: return true
+    case .failed: return false
+    case .pending: return nil
+    }
+  }
+
   static func verifyCaption(
     captionGUID: String,
     chatGUID: String,
@@ -96,10 +112,11 @@ enum PollCaptionStatus {
     repeat {
       if Task.isCancelled { return nil }
       do {
-        if try store.messageSendStatus(guid: captionGUID) != nil,
-          try store.messageBelongsToChat(messageGUID: captionGUID, chatGUID: chatGUID)
+        if let status = try store.messageSendStatus(guid: captionGUID),
+          try store.messageBelongsToChat(messageGUID: captionGUID, chatGUID: chatGUID),
+          let outcome = captionOutcome(for: status.state)
         {
-          return true
+          return outcome
         }
       } catch {
         // The database became unreadable mid-check. That is "we could not

--- a/Sources/imsg/Commands/PollCaptionStatus.swift
+++ b/Sources/imsg/Commands/PollCaptionStatus.swift
@@ -13,50 +13,76 @@ import IMsgCore
 ///
 /// Shape (`comment` key on both the CLI JSON object and the RPC result):
 /// - `requested` — whether a caption was supposed to be sent at all.
-/// - `sent` — whether it landed.
-/// - `error` — redacted failure text, only when `requested && !sent`.
+/// - `sent` — whether it landed: `true`, `false`, or `null` when delivery is
+///   unknown.
+/// - `error` — redacted failure text when delivery failed or is unresolved.
 /// - `disposition` / `retry_safe` — from ``DeliveryFailure`` when the transport
-///   reported one, so callers decide re-send safety from the disposition rather
-///   than by matching the message.
+///   reported one, or conservatively synthesized when verification expires.
+///   Callers decide re-send safety from these fields rather than by matching
+///   the message.
 /// - `verified` — present when the caption row was looked for in the target
 ///   chat. A bridge acknowledgement only proves the transport accepted the
 ///   send, so `sent` is not reported true on an acknowledgement alone when the
 ///   row can be checked. Absent means the check could not run at all.
 enum PollCaptionStatus {
+  enum VerificationOutcome: Equatable, Sendable {
+    case delivered
+    case failed
+    case unknown
+    case unavailable
+  }
+
   /// No caption was requested (`--no-comment` / `suppress_comment: true`).
   static var suppressed: [String: Any] { ["requested": false, "sent": false] }
 
   /// The caption was requested and the transport accepted it, but the row
   /// could not be checked (no readable database, or the bridge returned no
-  /// GUID to look for). `verified` is absent: we did not look, so we do not
-  /// claim either way.
-  static var sent: [String: Any] { ["requested": true, "sent": true] }
+  /// GUID to look for). `sent` is null and `verified` is absent: we did not
+  /// look, so we do not claim either way.
+  static var verificationUnavailable: [String: Any] {
+    ["requested": true, "sent": NSNull()]
+  }
 
   /// The caption was accepted *and* its row was found in the target chat.
   static var sentVerified: [String: Any] {
     ["requested": true, "sent": true, "verified": true]
   }
 
-  /// The transport accepted the caption but its row never appeared in the
-  /// target chat. Reported as not sent — a caption that never persisted leaves
-  /// exactly the question-less balloon this status exists to expose — and
-  /// carries the transport's own vocabulary for "cannot prove it ran".
-  static var acceptedButMissing: [String: Any] {
+  /// The transport accepted the caption, but its row was absent or still
+  /// pending when verification expired. This is explicitly unknown: Messages
+  /// can persist or deliver the row after the deadline, so retrying could
+  /// duplicate the caption.
+  static var deliveryUnknown: [String: Any] {
     [
       "requested": true,
-      "sent": false,
+      "sent": NSNull(),
       "verified": false,
       "error":
-        "The bridge accepted the caption but it never reached a sent state in the target chat.",
+        "The bridge accepted the caption, but delivery was not confirmed before the verification deadline.",
       "disposition": DeliveryDisposition.mayHaveCompleted.rawValue,
       "retry_safe": false,
     ]
   }
 
-  /// The caption was requested and did not land.
+  /// Messages recorded the accepted caption row as failed.
+  static var deliveryFailed: [String: Any] {
+    [
+      "requested": true,
+      "sent": false,
+      "verified": false,
+      "error": "Messages recorded the caption send as failed.",
+    ]
+  }
+
+  /// The caption transport returned an error. Only `not_started` proves it was
+  /// not sent; every other typed disposition and every untyped error remain
+  /// delivery-unknown.
   static func failed(_ error: Error) -> [String: Any] {
-    var status: [String: Any] = ["requested": true, "sent": false]
+    var status: [String: Any] = ["requested": true, "sent": NSNull()]
     if let failure = error as? DeliveryFailure {
+      if failure.retrySafe {
+        status["sent"] = false
+      }
       status["error"] = failure.description
       status["disposition"] = failure.disposition.rawValue
       status["retry_safe"] = failure.retrySafe
@@ -68,15 +94,20 @@ enum PollCaptionStatus {
 
   /// True when `status` describes a caption that was wanted but never arrived.
   static func isUndelivered(_ status: [String: Any]) -> Bool {
-    (status["requested"] as? Bool) == true && (status["sent"] as? Bool) != true
+    (status["requested"] as? Bool) == true && (status["sent"] as? Bool) == false
+  }
+
+  /// True when the caption may still arrive and must not be retried blindly.
+  static func isDeliveryUnknown(_ status: [String: Any]) -> Bool {
+    (status["requested"] as? Bool) == true && status["sent"] is NSNull
   }
 
   /// Waits for a caption row to appear in the target chat.
   ///
   /// Mirrors ``SentMessageVerifier``: poll the database until the row shows up
   /// or the deadline passes, because Messages persists an accepted send
-  /// asynchronously. Returns `nil` when the check cannot run — a missing store
-  /// or an empty GUID is "we did not look", never "it did not arrive".
+  /// asynchronously. Returns `.unavailable` when the check cannot run. A
+  /// missing store or empty GUID is "we did not look", never "it did not arrive".
   /// Bound for the JSON-RPC surface. Mutations there are drained by a single
   /// worker, so a caption that never lands would otherwise hold the lane for
   /// the full CLI deadline and stall every mutation queued behind it. Rows
@@ -90,14 +121,14 @@ enum PollCaptionStatus {
   /// as a delivered caption would recreate exactly the false success this
   /// status object exists to remove.
   ///
-  /// - Returns: `true` once Messages reports the row sent or delivered, `false`
-  ///   when it recorded a failure — waiting cannot change that — and `nil`
-  ///   while the send is still pending and may yet flip either way.
-  static func captionOutcome(for state: MessageSendState) -> Bool? {
+  /// - Returns: `.delivered` once Messages reports the row sent or delivered,
+  ///   `.failed` when it recorded a failure, and `.unknown` while the send is
+  ///   still pending and may yet flip either way.
+  static func captionOutcome(for state: MessageSendState) -> VerificationOutcome {
     switch state {
-    case .sent, .delivered: return true
-    case .failed: return false
-    case .pending: return nil
+    case .sent, .delivered: return .delivered
+    case .failed: return .failed
+    case .pending: return .unknown
     }
   }
 
@@ -106,11 +137,11 @@ enum PollCaptionStatus {
     chatGUID: String,
     store: MessageStore?,
     timeout: TimeInterval = 8
-  ) async -> Bool? {
-    guard let store, !captionGUID.isEmpty, !chatGUID.isEmpty else { return nil }
+  ) async -> VerificationOutcome {
+    guard let store, !captionGUID.isEmpty, !chatGUID.isEmpty else { return .unavailable }
     let deadline = Date().addingTimeInterval(timeout)
     repeat {
-      if Task.isCancelled { return nil }
+      if Task.isCancelled { return .unavailable }
       do {
         // `messageSendStatus` matches GUIDs COLLATE NOCASE but
         // `messageBelongsToChat` does not, so hand the membership check the
@@ -118,29 +149,29 @@ enum PollCaptionStatus {
         // that plainly landed reads back as missing.
         if let status = try store.messageSendStatus(guid: captionGUID) {
           let rowGUID = status.guid.isEmpty ? captionGUID : status.guid
-          if try store.messageBelongsToChat(messageGUID: rowGUID, chatGUID: chatGUID),
+          if try store.messageBelongsToChat(messageGUID: rowGUID, chatGUID: chatGUID) {
             let outcome = captionOutcome(for: status.state)
-          {
-            return outcome
+            if outcome != .unknown { return outcome }
           }
         }
       } catch {
         // The database became unreadable mid-check. That is "we could not
-        // look", never "it did not arrive" — returning false here would report
+        // look", never "it did not arrive". Returning `.failed` here would report
         // a delivery verdict this code did not earn.
-        return nil
+        return .unavailable
       }
       try? await Task.sleep(nanoseconds: 100_000_000)
     } while Date() < deadline
-    return false
+    return .unknown
   }
 
   /// Maps a verification outcome onto the reported status.
-  static func status(forVerification verified: Bool?) -> [String: Any] {
-    switch verified {
-    case true: return sentVerified
-    case false: return acceptedButMissing
-    case nil: return sent
+  static func status(forVerification outcome: VerificationOutcome) -> [String: Any] {
+    switch outcome {
+    case .delivered: return sentVerified
+    case .failed: return deliveryFailed
+    case .unknown: return deliveryUnknown
+    case .unavailable: return verificationUnavailable
     }
   }
 
@@ -156,7 +187,7 @@ enum PollCaptionStatus {
     chat: String,
     comment: String?,
     invokeBridge: (BridgeAction, [String: Any]) async throws -> [String: Any],
-    verify: ((_ captionGUID: String) async -> Bool?)? = nil
+    verify: ((_ captionGUID: String) async -> VerificationOutcome)? = nil
   ) async -> [String: Any] {
     guard let comment else {
       return data.merging(["comment": suppressed]) { _, new in new }
@@ -170,11 +201,13 @@ enum PollCaptionStatus {
           "message": comment,
         ])
       let captionGUID = (response["messageGuid"] as? String) ?? ""
-      let verified = verify == nil ? nil : await verify?(captionGUID) ?? nil
-      status = self.status(forVerification: verified)
-      if verified == false {
+      let outcome = await verify?(captionGUID) ?? .unavailable
+      status = self.status(forVerification: outcome)
+      if outcome == .unknown {
         FileHandle.standardError.write(
-          Data("[imsg] poll send: caption \(captionGUID) never appeared in \(chat)\n".utf8))
+          Data(
+            "[imsg] poll send: caption \(captionGUID) delivery was not verified in \(chat); automatic retry is unsafe\n"
+              .utf8))
       }
     } catch {
       let pollGuid = (data["messageGuid"] as? String) ?? ""

--- a/Sources/imsg/Commands/PollCaptionStatus.swift
+++ b/Sources/imsg/Commands/PollCaptionStatus.swift
@@ -77,6 +77,14 @@ enum PollCaptionStatus {
   /// or the deadline passes, because Messages persists an accepted send
   /// asynchronously. Returns `nil` when the check cannot run — a missing store
   /// or an empty GUID is "we did not look", never "it did not arrive".
+  /// Bound for the JSON-RPC surface. Mutations there are drained by a single
+  /// worker, so a caption that never lands would otherwise hold the lane for
+  /// the full CLI deadline and stall every mutation queued behind it. Rows
+  /// normally appear well inside a second; timing out here reports
+  /// `may_have_completed`, which tells callers not to retry, so a pessimistic
+  /// bound costs honesty about certainty rather than causing duplicate sends.
+  static let rpcVerifyTimeout: TimeInterval = 2
+
   static func verifyCaption(
     captionGUID: String,
     chatGUID: String,
@@ -87,10 +95,17 @@ enum PollCaptionStatus {
     let deadline = Date().addingTimeInterval(timeout)
     repeat {
       if Task.isCancelled { return nil }
-      if (try? store.messageSendStatus(guid: captionGUID)) != nil,
-        (try? store.messageBelongsToChat(messageGUID: captionGUID, chatGUID: chatGUID)) == true
-      {
-        return true
+      do {
+        if try store.messageSendStatus(guid: captionGUID) != nil,
+          try store.messageBelongsToChat(messageGUID: captionGUID, chatGUID: chatGUID)
+        {
+          return true
+        }
+      } catch {
+        // The database became unreadable mid-check. That is "we could not
+        // look", never "it did not arrive" — returning false here would report
+        // a delivery verdict this code did not earn.
+        return nil
       }
       try? await Task.sleep(nanoseconds: 100_000_000)
     } while Date() < deadline

--- a/Sources/imsg/Commands/PollCaptionStatus.swift
+++ b/Sources/imsg/Commands/PollCaptionStatus.swift
@@ -1,0 +1,80 @@
+import Foundation
+import IMsgCore
+
+/// Delivery status for the plain caption message that carries a poll's question.
+///
+/// Messages never renders a poll's title on the balloon, so the caption *is* the
+/// question as far as recipients are concerned. The caption is sent after the
+/// poll and is deliberately best-effort — the poll already landed, and retrying
+/// the pair would duplicate the balloon. Best-effort must not mean silent: a
+/// dropped caption leaves a question-less poll on screen while the caller sees
+/// nothing but success, so `poll send` reports the outcome in its result
+/// payload instead of leaving it on stderr where machine callers never look.
+///
+/// Shape (`comment` key on both the CLI JSON object and the RPC result):
+/// - `requested` — whether a caption was supposed to be sent at all.
+/// - `sent` — whether it landed.
+/// - `error` — redacted failure text, only when `requested && !sent`.
+/// - `disposition` / `retry_safe` — from ``DeliveryFailure`` when the transport
+///   reported one, so callers decide re-send safety from the disposition rather
+///   than by matching the message.
+enum PollCaptionStatus {
+  /// No caption was requested (`--no-comment` / `suppress_comment: true`).
+  static var suppressed: [String: Any] { ["requested": false, "sent": false] }
+
+  /// The caption was requested and the transport accepted it.
+  static var sent: [String: Any] { ["requested": true, "sent": true] }
+
+  /// The caption was requested and did not land.
+  static func failed(_ error: Error) -> [String: Any] {
+    var status: [String: Any] = ["requested": true, "sent": false]
+    if let failure = error as? DeliveryFailure {
+      status["error"] = failure.description
+      status["disposition"] = failure.disposition.rawValue
+      status["retry_safe"] = failure.retrySafe
+    } else {
+      status["error"] = String(describing: error)
+    }
+    return status
+  }
+
+  /// True when `status` describes a caption that was wanted but never arrived.
+  static func isUndelivered(_ status: [String: Any]) -> Bool {
+    (status["requested"] as? Bool) == true && (status["sent"] as? Bool) != true
+  }
+
+  /// Sends the caption that carries a poll's question and folds the outcome into
+  /// the poll payload under `comment`. Pass `comment: nil` when it is suppressed.
+  ///
+  /// Best-effort, mirroring the RPC path: the poll already delivered, so a
+  /// caption failure must not fail the command — re-sending would duplicate the
+  /// balloon. Best-effort is not the same as silent, though, so the outcome
+  /// rides along in the emitted object; stderr keeps the human-facing note.
+  static func sendCaption(
+    after data: [String: Any],
+    chat: String,
+    comment: String?,
+    invokeBridge: (BridgeAction, [String: Any]) async throws -> [String: Any]
+  ) async -> [String: Any] {
+    guard let comment else {
+      return data.merging(["comment": suppressed]) { _, new in new }
+    }
+    let status: [String: Any]
+    do {
+      _ = try await invokeBridge(
+        .sendMessage,
+        [
+          "chatGuid": chat,
+          "message": comment,
+        ])
+      status = sent
+    } catch {
+      let pollGuid = (data["messageGuid"] as? String) ?? ""
+      let pollDescription = pollGuid.isEmpty ? "queued poll" : "poll \(pollGuid)"
+      FileHandle.standardError.write(
+        Data("[imsg] poll send: comment echo failed for \(pollDescription): \(error)\n".utf8))
+      status = failed(error)
+    }
+    return data.merging(["comment": status]) { _, new in new }
+  }
+}

--- a/Sources/imsg/Commands/PollCaptionStatus.swift
+++ b/Sources/imsg/Commands/PollCaptionStatus.swift
@@ -43,7 +43,8 @@ enum PollCaptionStatus {
     ["requested": true, "sent": NSNull()]
   }
 
-  /// The caption was accepted *and* its row was found in the target chat.
+  /// The caption was accepted and Messages recorded it as delivered in the
+  /// target chat.
   static var sentVerified: [String: Any] {
     ["requested": true, "sent": true, "verified": true]
   }
@@ -121,14 +122,14 @@ enum PollCaptionStatus {
   /// as a delivered caption would recreate exactly the false success this
   /// status object exists to remove.
   ///
-  /// - Returns: `.delivered` once Messages reports the row sent or delivered,
-  ///   `.failed` when it recorded a failure, and `.unknown` while the send is
-  ///   still pending and may yet flip either way.
+  /// - Returns: `.delivered` once Messages reports remote delivery, `.failed`
+  ///   when it recorded a failure, and `.unknown` while the row is pending or
+  ///   only locally sent and may yet flip either way.
   static func captionOutcome(for state: MessageSendState) -> VerificationOutcome {
     switch state {
-    case .sent, .delivered: return .delivered
+    case .delivered: return .delivered
     case .failed: return .failed
-    case .pending: return .unknown
+    case .pending, .sent: return .unknown
     }
   }
 

--- a/Sources/imsg/Commands/PollCaptionStatus.swift
+++ b/Sources/imsg/Commands/PollCaptionStatus.swift
@@ -18,12 +18,40 @@ import IMsgCore
 /// - `disposition` / `retry_safe` — from ``DeliveryFailure`` when the transport
 ///   reported one, so callers decide re-send safety from the disposition rather
 ///   than by matching the message.
+/// - `verified` — present when the caption row was looked for in the target
+///   chat. A bridge acknowledgement only proves the transport accepted the
+///   send, so `sent` is not reported true on an acknowledgement alone when the
+///   row can be checked. Absent means the check could not run at all.
 enum PollCaptionStatus {
   /// No caption was requested (`--no-comment` / `suppress_comment: true`).
   static var suppressed: [String: Any] { ["requested": false, "sent": false] }
 
-  /// The caption was requested and the transport accepted it.
+  /// The caption was requested and the transport accepted it, but the row
+  /// could not be checked (no readable database, or the bridge returned no
+  /// GUID to look for). `verified` is absent: we did not look, so we do not
+  /// claim either way.
   static var sent: [String: Any] { ["requested": true, "sent": true] }
+
+  /// The caption was accepted *and* its row was found in the target chat.
+  static var sentVerified: [String: Any] {
+    ["requested": true, "sent": true, "verified": true]
+  }
+
+  /// The transport accepted the caption but its row never appeared in the
+  /// target chat. Reported as not sent — a caption that never persisted leaves
+  /// exactly the question-less balloon this status exists to expose — and
+  /// carries the transport's own vocabulary for "cannot prove it ran".
+  static var acceptedButMissing: [String: Any] {
+    [
+      "requested": true,
+      "sent": false,
+      "verified": false,
+      "error":
+        "The bridge accepted the caption but no matching row appeared in the target chat.",
+      "disposition": DeliveryDisposition.mayHaveCompleted.rawValue,
+      "retry_safe": false,
+    ]
+  }
 
   /// The caption was requested and did not land.
   static func failed(_ error: Error) -> [String: Any] {
@@ -43,6 +71,41 @@ enum PollCaptionStatus {
     (status["requested"] as? Bool) == true && (status["sent"] as? Bool) != true
   }
 
+  /// Waits for a caption row to appear in the target chat.
+  ///
+  /// Mirrors ``SentMessageVerifier``: poll the database until the row shows up
+  /// or the deadline passes, because Messages persists an accepted send
+  /// asynchronously. Returns `nil` when the check cannot run — a missing store
+  /// or an empty GUID is "we did not look", never "it did not arrive".
+  static func verifyCaption(
+    captionGUID: String,
+    chatGUID: String,
+    store: MessageStore?,
+    timeout: TimeInterval = 8
+  ) async -> Bool? {
+    guard let store, !captionGUID.isEmpty, !chatGUID.isEmpty else { return nil }
+    let deadline = Date().addingTimeInterval(timeout)
+    repeat {
+      if Task.isCancelled { return nil }
+      if (try? store.messageSendStatus(guid: captionGUID)) != nil,
+        (try? store.messageBelongsToChat(messageGUID: captionGUID, chatGUID: chatGUID)) == true
+      {
+        return true
+      }
+      try? await Task.sleep(nanoseconds: 100_000_000)
+    } while Date() < deadline
+    return false
+  }
+
+  /// Maps a verification outcome onto the reported status.
+  static func status(forVerification verified: Bool?) -> [String: Any] {
+    switch verified {
+    case true: return sentVerified
+    case false: return acceptedButMissing
+    case nil: return sent
+    }
+  }
+
   /// Sends the caption that carries a poll's question and folds the outcome into
   /// the poll payload under `comment`. Pass `comment: nil` when it is suppressed.
   ///
@@ -54,20 +117,27 @@ enum PollCaptionStatus {
     after data: [String: Any],
     chat: String,
     comment: String?,
-    invokeBridge: (BridgeAction, [String: Any]) async throws -> [String: Any]
+    invokeBridge: (BridgeAction, [String: Any]) async throws -> [String: Any],
+    verify: ((_ captionGUID: String) async -> Bool?)? = nil
   ) async -> [String: Any] {
     guard let comment else {
       return data.merging(["comment": suppressed]) { _, new in new }
     }
     let status: [String: Any]
     do {
-      _ = try await invokeBridge(
+      let response = try await invokeBridge(
         .sendMessage,
         [
           "chatGuid": chat,
           "message": comment,
         ])
-      status = sent
+      let captionGUID = (response["messageGuid"] as? String) ?? ""
+      let verified = verify == nil ? nil : await verify?(captionGUID) ?? nil
+      status = self.status(forVerification: verified)
+      if verified == false {
+        FileHandle.standardError.write(
+          Data("[imsg] poll send: caption \(captionGUID) never appeared in \(chat)\n".utf8))
+      }
     } catch {
       let pollGuid = (data["messageGuid"] as? String) ?? ""
       let pollDescription = pollGuid.isEmpty ? "queued poll" : "poll \(pollGuid)"

--- a/Sources/imsg/Commands/PollCaptionStatus.swift
+++ b/Sources/imsg/Commands/PollCaptionStatus.swift
@@ -1,29 +1,8 @@
 import Foundation
 import IMsgCore
 
-/// Delivery status for the plain caption message that carries a poll's question.
-///
-/// Messages never renders a poll's title on the balloon, so the caption *is* the
-/// question as far as recipients are concerned. The caption is sent after the
-/// poll and is deliberately best-effort — the poll already landed, and retrying
-/// the pair would duplicate the balloon. Best-effort must not mean silent: a
-/// dropped caption leaves a question-less poll on screen while the caller sees
-/// nothing but success, so `poll send` reports the outcome in its result
-/// payload instead of leaving it on stderr where machine callers never look.
-///
-/// Shape (`comment` key on both the CLI JSON object and the RPC result):
-/// - `requested` — whether a caption was supposed to be sent at all.
-/// - `sent` — whether it landed: `true`, `false`, or `null` when delivery is
-///   unknown.
-/// - `error` — redacted failure text when delivery failed or is unresolved.
-/// - `disposition` / `retry_safe` — from ``DeliveryFailure`` when the transport
-///   reported one, or conservatively synthesized when verification expires.
-///   Callers decide re-send safety from these fields rather than by matching
-///   the message.
-/// - `verified` — present when the caption row was looked for in the target
-///   chat. A bridge acknowledgement only proves the transport accepted the
-///   send, so `sent` is not reported true on an acknowledgement alone when the
-///   row can be checked. Absent means the check could not run at all.
+/// The balloon and its question caption are separate sends. Keep caption failure
+/// or uncertainty separate so callers never retry an already-created poll.
 enum PollCaptionStatus {
   enum VerificationOutcome: Equatable, Sendable {
     case delivered
@@ -32,27 +11,16 @@ enum PollCaptionStatus {
     case unavailable
   }
 
-  /// No caption was requested (`--no-comment` / `suppress_comment: true`).
   static var suppressed: [String: Any] { ["requested": false, "sent": false] }
 
-  /// The caption was requested and the transport accepted it, but the row
-  /// could not be checked (no readable database, or the bridge returned no
-  /// GUID to look for). `sent` is null and `verified` is absent: we did not
-  /// look, so we do not claim either way.
   static var verificationUnavailable: [String: Any] {
     ["requested": true, "sent": NSNull()]
   }
 
-  /// The caption was accepted and Messages recorded it as delivered in the
-  /// target chat.
   static var sentVerified: [String: Any] {
     ["requested": true, "sent": true, "verified": true]
   }
 
-  /// The transport accepted the caption, but its row was absent or still
-  /// pending when verification expired. This is explicitly unknown: Messages
-  /// can persist or deliver the row after the deadline, so retrying could
-  /// duplicate the caption.
   static var deliveryUnknown: [String: Any] {
     [
       "requested": true,
@@ -65,7 +33,6 @@ enum PollCaptionStatus {
     ]
   }
 
-  /// Messages recorded the accepted caption row as failed.
   static var deliveryFailed: [String: Any] {
     [
       "requested": true,
@@ -103,35 +70,9 @@ enum PollCaptionStatus {
     (status["requested"] as? Bool) == true && status["sent"] is NSNull
   }
 
-  /// Waits for a caption row to appear in the target chat.
-  ///
-  /// Mirrors ``SentMessageVerifier``: poll the database until the row shows up
-  /// or the deadline passes, because Messages persists an accepted send
-  /// asynchronously. Returns `.unavailable` when the check cannot run. A
-  /// missing store or empty GUID is "we did not look", never "it did not arrive".
-  /// Bound for the JSON-RPC surface. Mutations there are drained by a single
-  /// worker, so a caption that never lands would otherwise hold the lane for
-  /// the full CLI deadline and stall every mutation queued behind it. Rows
-  /// normally appear well inside a second; timing out here reports
-  /// `may_have_completed`, which tells callers not to retry, so a pessimistic
-  /// bound costs honesty about certainty rather than causing duplicate sends.
+  // RPC mutations share one lane. Bound the extra verification wait so an
+  // offline recipient does not hold every queued mutation for the CLI deadline.
   static let rpcVerifyTimeout: TimeInterval = 2
-
-  /// Reads a caption row's send state. A row existing is not delivery: Messages
-  /// records failed and still-pending sends as rows too, and reporting either
-  /// as a delivered caption would recreate exactly the false success this
-  /// status object exists to remove.
-  ///
-  /// - Returns: `.delivered` once Messages reports remote delivery, `.failed`
-  ///   when it recorded a failure, and `.unknown` while the row is pending or
-  ///   only locally sent and may yet flip either way.
-  static func captionOutcome(for state: MessageSendState) -> VerificationOutcome {
-    switch state {
-    case .delivered: return .delivered
-    case .failed: return .failed
-    case .pending, .sent: return .unknown
-    }
-  }
 
   static func verifyCaption(
     captionGUID: String,
@@ -140,7 +81,8 @@ enum PollCaptionStatus {
     timeout: TimeInterval = 8
   ) async -> VerificationOutcome {
     guard let store, !captionGUID.isEmpty, !chatGUID.isEmpty else { return .unavailable }
-    let deadline = Date().addingTimeInterval(timeout)
+    let clock = ContinuousClock()
+    let deadline = clock.now + .seconds(max(0, timeout))
     repeat {
       if Task.isCancelled { return .unavailable }
       do {
@@ -151,8 +93,11 @@ enum PollCaptionStatus {
         if let status = try store.messageSendStatus(guid: captionGUID) {
           let rowGUID = status.guid.isEmpty ? captionGUID : status.guid
           if try store.messageBelongsToChat(messageGUID: rowGUID, chatGUID: chatGUID) {
-            let outcome = captionOutcome(for: status.state)
-            if outcome != .unknown { return outcome }
+            switch status.state {
+            case .delivered: return .delivered
+            case .failed: return .failed
+            case .pending, .sent: break
+            }
           }
         }
       } catch {
@@ -161,28 +106,28 @@ enum PollCaptionStatus {
         // a delivery verdict this code did not earn.
         return .unavailable
       }
-      try? await Task.sleep(nanoseconds: 100_000_000)
-    } while Date() < deadline
+      let nextPoll = clock.now + .milliseconds(100)
+      try? await clock.sleep(until: min(nextPoll, deadline))
+    } while clock.now < deadline
     return .unknown
   }
 
   /// Maps a verification outcome onto the reported status.
-  static func status(forVerification outcome: VerificationOutcome) -> [String: Any] {
+  static func status(
+    forVerification outcome: VerificationOutcome, messageGUID: String
+  ) -> [String: Any] {
+    var status: [String: Any]
     switch outcome {
-    case .delivered: return sentVerified
-    case .failed: return deliveryFailed
-    case .unknown: return deliveryUnknown
-    case .unavailable: return verificationUnavailable
+    case .delivered: status = sentVerified
+    case .failed: status = deliveryFailed
+    case .unknown: status = deliveryUnknown
+    case .unavailable: status = verificationUnavailable
     }
+    if !messageGUID.isEmpty { status["message_guid"] = messageGUID }
+    return status
   }
 
-  /// Sends the caption that carries a poll's question and folds the outcome into
-  /// the poll payload under `comment`. Pass `comment: nil` when it is suppressed.
-  ///
-  /// Best-effort, mirroring the RPC path: the poll already delivered, so a
-  /// caption failure must not fail the command — re-sending would duplicate the
-  /// balloon. Best-effort is not the same as silent, though, so the outcome
-  /// rides along in the emitted object; stderr keeps the human-facing note.
+  /// Finishes the caption before CLI output; the successful poll remains successful.
   static func sendCaption(
     after data: [String: Any],
     chat: String,
@@ -203,7 +148,7 @@ enum PollCaptionStatus {
         ])
       let captionGUID = (response["messageGuid"] as? String) ?? ""
       let outcome = await verify?(captionGUID) ?? .unavailable
-      status = self.status(forVerification: outcome)
+      status = self.status(forVerification: outcome, messageGUID: captionGUID)
       if outcome == .unknown {
         FileHandle.standardError.write(
           Data(

--- a/Sources/imsg/Commands/PollCaptionStatus.swift
+++ b/Sources/imsg/Commands/PollCaptionStatus.swift
@@ -112,11 +112,17 @@ enum PollCaptionStatus {
     repeat {
       if Task.isCancelled { return nil }
       do {
-        if let status = try store.messageSendStatus(guid: captionGUID),
-          try store.messageBelongsToChat(messageGUID: captionGUID, chatGUID: chatGUID),
-          let outcome = captionOutcome(for: status.state)
-        {
-          return outcome
+        // `messageSendStatus` matches GUIDs COLLATE NOCASE but
+        // `messageBelongsToChat` does not, so hand the membership check the
+        // row's own GUID rather than the bridge's casing. Otherwise a caption
+        // that plainly landed reads back as missing.
+        if let status = try store.messageSendStatus(guid: captionGUID) {
+          let rowGUID = status.guid.isEmpty ? captionGUID : status.guid
+          if try store.messageBelongsToChat(messageGUID: rowGUID, chatGUID: chatGUID),
+            let outcome = captionOutcome(for: status.state)
+          {
+            return outcome
+          }
         }
       } catch {
         // The database became unreadable mid-check. That is "we could not

--- a/Sources/imsg/Commands/PollCommand.swift
+++ b/Sources/imsg/Commands/PollCommand.swift
@@ -21,10 +21,13 @@ enum PollCommand {
       visible context before the poll.
 
       The caption is best-effort but not silent: the result reports it under
-      `comment` (`requested`, `sent`, plus `error`/`disposition`/`retry_safe`
-      when it fails). A requested caption that was not sent means the balloon is
-      on screen with no question — re-send the caption text alone, never the
-      poll, which would duplicate the balloon.
+      `comment` (`requested`, `sent`, `verified`, plus
+      `error`/`disposition`/`retry_safe` when it fails). A bridge
+      acknowledgement is not proof of delivery, so the caption's row is looked
+      up in the target chat before `sent` is reported true. A requested caption
+      that was not sent means the balloon is on screen with no question —
+      re-send the caption text alone, never the poll, which would duplicate the
+      balloon.
       """,
     signature: CommandSignatures.withRuntimeFlags(
       CommandSignature(
@@ -87,12 +90,14 @@ enum PollCommand {
     invokeBridge: @escaping (BridgeAction, [String: Any]) async throws -> [String: Any] = {
       action, params in
       try await IMsgBridgeClient.shared.invoke(action: action, params: params)
-    }
+    },
+    verifyCaption: ((_ captionGUID: String) async -> Bool?)? = nil
   ) async throws {
     switch values.argument(0) {
     case "send":
       try await runSend(
-        values: values, runtime: runtime, storeFactory: storeFactory, invokeBridge: invokeBridge)
+        values: values, runtime: runtime, storeFactory: storeFactory, invokeBridge: invokeBridge,
+        verifyCaption: verifyCaption)
     case "vote":
       try await runVote(
         remove: false,
@@ -110,7 +115,8 @@ enum PollCommand {
     values: ParsedValues,
     runtime: RuntimeOptions,
     storeFactory: @escaping (String) throws -> MessageStore,
-    invokeBridge: @escaping (BridgeAction, [String: Any]) async throws -> [String: Any]
+    invokeBridge: @escaping (BridgeAction, [String: Any]) async throws -> [String: Any],
+    verifyCaption: ((_ captionGUID: String) async -> Bool?)? = nil
   ) async throws {
     if values.option("comment") != nil, values.flag("noComment") {
       throw ParsedValuesError.invalidOption("comment")
@@ -147,6 +153,17 @@ enum PollCommand {
     // knowledge of this. --comment overrides the echoed text.
     let comment = values.option("comment").flatMap { $0.isEmpty ? nil : $0 } ?? question
     let wantsComment = !values.flag("noComment") && !comment.isEmpty
+    // A bridge acknowledgement is not proof the caption row persisted, so look
+    // for it. `try?`: an unreadable database means we simply do not check, and
+    // must never turn that into a delivery claim either way.
+    let dbPath = values.option("db") ?? MessageStore.defaultPath
+    let verifier =
+      verifyCaption
+      ?? { captionGUID in
+        // Opened lazily: a suppressed caption must not pay for a database open.
+        await PollCaptionStatus.verifyCaption(
+          captionGUID: captionGUID, chatGUID: chat, store: try? storeFactory(dbPath))
+      }
 
     _ = try await BridgeOutput.invokeAndEmit(
       action: .sendPoll,
@@ -158,7 +175,8 @@ enum PollCommand {
           after: data,
           chat: chat,
           comment: wantsComment ? comment : nil,
-          invokeBridge: invokeBridge
+          invokeBridge: invokeBridge,
+          verify: verifier
         )
       },
       summary: sendSummary

--- a/Sources/imsg/Commands/PollCommand.swift
+++ b/Sources/imsg/Commands/PollCommand.swift
@@ -22,12 +22,12 @@ enum PollCommand {
 
       The caption is best-effort but not silent: the result reports it under
       `comment` (`requested`, `sent`, `verified`, plus
-      `error`/`disposition`/`retry_safe` when it fails). A bridge
+      `error`/`disposition`/`retry_safe` when it fails or remains unresolved). A bridge
       acknowledgement is not proof of delivery, so the caption's row is looked
-      up in the target chat before `sent` is reported true. A requested caption
-      that was not sent means the balloon is on screen with no question —
-      re-send the caption text alone, never the poll, which would duplicate the
-      balloon.
+      up in the target chat before `sent` is reported true. `sent: null` means
+      delivery is unknown and must not be retried automatically. Re-send the
+      caption text alone only when `retry_safe` is true; never re-send the poll,
+      which would duplicate the balloon.
       """,
     signature: CommandSignatures.withRuntimeFlags(
       CommandSignature(
@@ -91,7 +91,7 @@ enum PollCommand {
       action, params in
       try await IMsgBridgeClient.shared.invoke(action: action, params: params)
     },
-    verifyCaption: ((_ captionGUID: String) async -> Bool?)? = nil
+    verifyCaption: ((_ captionGUID: String) async -> PollCaptionStatus.VerificationOutcome)? = nil
   ) async throws {
     switch values.argument(0) {
     case "send":
@@ -116,7 +116,7 @@ enum PollCommand {
     runtime: RuntimeOptions,
     storeFactory: @escaping (String) throws -> MessageStore,
     invokeBridge: @escaping (BridgeAction, [String: Any]) async throws -> [String: Any],
-    verifyCaption: ((_ captionGUID: String) async -> Bool?)? = nil
+    verifyCaption: ((_ captionGUID: String) async -> PollCaptionStatus.VerificationOutcome)? = nil
   ) async throws {
     if values.option("comment") != nil, values.flag("noComment") {
       throw ParsedValuesError.invalidOption("comment")
@@ -183,15 +183,20 @@ enum PollCommand {
     )
   }
 
-  /// A poll whose caption never landed shows no question at all, so say so
-  /// rather than reporting a bare success.
+  /// Call out a confirmed caption failure or an unresolved outcome without
+  /// turning uncertainty into unsafe retry advice.
   private static func sendSummary(_ data: [String: Any]) -> String {
     let guid = (data["messageGuid"] as? String) ?? ""
     let base = guid.isEmpty ? "poll: queued" : "poll: sent (guid=\(guid))"
-    guard let status = data["comment"] as? [String: Any],
-      PollCaptionStatus.isUndelivered(status)
-    else { return base }
-    return "\(base); caption NOT delivered — the question is not visible on the balloon"
+    guard let status = data["comment"] as? [String: Any] else { return base }
+    if PollCaptionStatus.isDeliveryUnknown(status) {
+      return "\(base); caption delivery UNKNOWN; do not retry automatically"
+    }
+    guard PollCaptionStatus.isUndelivered(status) else { return base }
+    if (status["retry_safe"] as? Bool) == true {
+      return "\(base); caption NOT delivered; re-send the caption only, never the poll"
+    }
+    return "\(base); caption NOT delivered; automatic retry is not known to be safe"
   }
 
   private static func runVote(

--- a/Sources/imsg/Commands/PollCommand.swift
+++ b/Sources/imsg/Commands/PollCommand.swift
@@ -19,6 +19,12 @@ enum PollCommand {
       appears for free; `--comment` overrides the caption text when it should
       differ from the title. Use `--no-comment` when the caller renders its own
       visible context before the poll.
+
+      The caption is best-effort but not silent: the result reports it under
+      `comment` (`requested`, `sent`, plus `error`/`disposition`/`retry_safe`
+      when it fails). A requested caption that was not sent means the balloon is
+      on screen with no question — re-send the caption text alone, never the
+      poll, which would duplicate the balloon.
       """,
     signature: CommandSignatures.withRuntimeFlags(
       CommandSignature(
@@ -129,16 +135,6 @@ enum PollCommand {
       params["selectedMessageGuid"] = reply
     }
 
-    let data = try await BridgeOutput.invokeAndEmit(
-      action: .sendPoll,
-      params: params,
-      runtime: runtime,
-      invokeBridge: invokeBridge
-    ) { data in
-      let guid = (data["messageGuid"] as? String) ?? ""
-      return guid.isEmpty ? "poll: queued" : "poll: sent (guid=\(guid))"
-    }
-
     // Messages renders only the poll options on the balloon — the poll title
     // (payload item.title) is never shown to recipients. To make the poll's
     // question visible we send it as a PLAIN caption message right after the
@@ -150,24 +146,34 @@ enum PollCommand {
     // Callers set only --question; the caption comes for free, so agents need no
     // knowledge of this. --comment overrides the echoed text.
     let comment = values.option("comment").flatMap { $0.isEmpty ? nil : $0 } ?? question
-    let pollGuid = (data["messageGuid"] as? String) ?? ""
-    if !values.flag("noComment"), !comment.isEmpty {
-      // Best-effort, mirroring the RPC path: the poll already delivered, so a
-      // caption failure must not exit nonzero — a retry would send a duplicate
-      // poll. Report the failure on stderr and leave the poll success intact.
-      do {
-        _ = try await invokeBridge(
-          .sendMessage,
-          [
-            "chatGuid": chat,
-            "message": comment,
-          ])
-      } catch {
-        let pollDescription = pollGuid.isEmpty ? "queued poll" : "poll \(pollGuid)"
-        FileHandle.standardError.write(
-          Data("[imsg] poll send: comment echo failed for \(pollDescription): \(error)\n".utf8))
-      }
-    }
+    let wantsComment = !values.flag("noComment") && !comment.isEmpty
+
+    _ = try await BridgeOutput.invokeAndEmit(
+      action: .sendPoll,
+      params: params,
+      runtime: runtime,
+      invokeBridge: invokeBridge,
+      finalize: { data in
+        await PollCaptionStatus.sendCaption(
+          after: data,
+          chat: chat,
+          comment: wantsComment ? comment : nil,
+          invokeBridge: invokeBridge
+        )
+      },
+      summary: sendSummary
+    )
+  }
+
+  /// A poll whose caption never landed shows no question at all, so say so
+  /// rather than reporting a bare success.
+  private static func sendSummary(_ data: [String: Any]) -> String {
+    let guid = (data["messageGuid"] as? String) ?? ""
+    let base = guid.isEmpty ? "poll: queued" : "poll: sent (guid=\(guid))"
+    guard let status = data["comment"] as? [String: Any],
+      PollCaptionStatus.isUndelivered(status)
+    else { return base }
+    return "\(base); caption NOT delivered — the question is not visible on the balloon"
   }
 
   private static func runVote(

--- a/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
+++ b/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
@@ -279,13 +279,24 @@ extension RPCServer {
       result["comment"] = PollCaptionStatus.suppressed
     } else {
       do {
-        _ = try await invokeBridge(
+        let captionData = try await invokeBridge(
           action: .sendMessage,
           params: [
             "chatGuid": chatGUID,
             "message": comment,
           ])
-        result["comment"] = PollCaptionStatus.sent
+        // The bridge acknowledging the send is not proof the caption row
+        // reached the chat, and an accepted-but-absent caption leaves exactly
+        // the question-less balloon this status exists to expose.
+        let captionGUID = (captionData["messageGuid"] as? String) ?? ""
+        let verified = await captionVerifier(
+          captionGUID, chatGUID, await databaseResources.available()?.store)
+        result["comment"] = PollCaptionStatus.status(forVerification: verified)
+        if verified == false {
+          FileHandle.standardError.write(
+            Data(
+              "[imsg] poll.send: caption \(captionGUID) never appeared in \(chatGUID)\n".utf8))
+        }
       } catch let failure as DeliveryFailure {
         if failure.disposition == .stillInFlight {
           poisonAfterResponse = failure

--- a/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
+++ b/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
@@ -291,7 +291,8 @@ extension RPCServer {
         let captionGUID = (captionData["messageGuid"] as? String) ?? ""
         let outcome = await captionVerifier(
           captionGUID, chatGUID, await databaseResources.available()?.store)
-        result["comment"] = PollCaptionStatus.status(forVerification: outcome)
+        result["comment"] = PollCaptionStatus.status(
+          forVerification: outcome, messageGUID: captionGUID)
         if outcome == .unknown {
           FileHandle.standardError.write(
             Data(

--- a/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
+++ b/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
@@ -273,7 +273,11 @@ extension RPCServer {
     // comment failure must not fail the RPC.
     let comment = commentValue.flatMap { $0.isEmpty ? nil : $0 } ?? question
     var poisonAfterResponse: DeliveryFailure?
-    if !suppressComment, !comment.isEmpty {
+    let pollGuid = (data["messageGuid"] as? String) ?? ""
+    let pollDescription = pollGuid.isEmpty ? "queued poll" : "poll \(pollGuid)"
+    if suppressComment || comment.isEmpty {
+      result["comment"] = PollCaptionStatus.suppressed
+    } else {
       do {
         _ = try await invokeBridge(
           action: .sendMessage,
@@ -281,21 +285,23 @@ extension RPCServer {
             "chatGuid": chatGUID,
             "message": comment,
           ])
+        result["comment"] = PollCaptionStatus.sent
       } catch let failure as DeliveryFailure {
         if failure.disposition == .stillInFlight {
           poisonAfterResponse = failure
         }
-        let pollGuid = (data["messageGuid"] as? String) ?? ""
-        let pollDescription = pollGuid.isEmpty ? "queued poll" : "poll \(pollGuid)"
+        result["comment"] = PollCaptionStatus.failed(failure)
         FileHandle.standardError.write(
           Data("[imsg] poll.send: comment echo delivery unresolved for \(pollDescription)\n".utf8))
       } catch {
-        let pollGuid = (data["messageGuid"] as? String) ?? ""
-        let pollDescription = pollGuid.isEmpty ? "queued poll" : "poll \(pollGuid)"
+        result["comment"] = PollCaptionStatus.failed(error)
         FileHandle.standardError.write(
           Data("[imsg] poll.send: comment echo failed for \(pollDescription): \(error)\n".utf8))
       }
     }
+    // `ok` stays true when only the caption failed: the poll balloon really did
+    // land, and a caller that treats this as a failed send would re-send and
+    // duplicate it. `comment` is what tells them the question is missing.
     respond(id: id, result: result)
     if let poisonAfterResponse {
       throw RPCMutationPoisonSignal(failure: poisonAfterResponse)

--- a/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
+++ b/Sources/imsg/RPCServer+BridgeMessageHandlers.swift
@@ -289,21 +289,25 @@ extension RPCServer {
         // reached the chat, and an accepted-but-absent caption leaves exactly
         // the question-less balloon this status exists to expose.
         let captionGUID = (captionData["messageGuid"] as? String) ?? ""
-        let verified = await captionVerifier(
+        let outcome = await captionVerifier(
           captionGUID, chatGUID, await databaseResources.available()?.store)
-        result["comment"] = PollCaptionStatus.status(forVerification: verified)
-        if verified == false {
+        result["comment"] = PollCaptionStatus.status(forVerification: outcome)
+        if outcome == .unknown {
           FileHandle.standardError.write(
             Data(
-              "[imsg] poll.send: caption \(captionGUID) never appeared in \(chatGUID)\n".utf8))
+              "[imsg] poll.send: caption \(captionGUID) delivery was not verified in \(chatGUID); automatic retry is unsafe\n"
+                .utf8))
         }
       } catch let failure as DeliveryFailure {
         if failure.disposition == .stillInFlight {
           poisonAfterResponse = failure
         }
         result["comment"] = PollCaptionStatus.failed(failure)
+        let failureState = failure.retrySafe ? "failed before dispatch" : "delivery unresolved"
         FileHandle.standardError.write(
-          Data("[imsg] poll.send: comment echo delivery unresolved for \(pollDescription)\n".utf8))
+          Data(
+            "[imsg] poll.send: comment echo \(failureState) for \(pollDescription): \(failure)\n"
+              .utf8))
       } catch {
         result["comment"] = PollCaptionStatus.failed(error)
         FileHandle.standardError.write(
@@ -312,7 +316,8 @@ extension RPCServer {
     }
     // `ok` stays true when only the caption failed: the poll balloon really did
     // land, and a caller that treats this as a failed send would re-send and
-    // duplicate it. `comment` is what tells them the question is missing.
+    // duplicate it. `comment` reports confirmed failure separately from an
+    // outcome that is still unknown.
     respond(id: id, result: result)
     if let poisonAfterResponse {
       throw RPCMutationPoisonSignal(failure: poisonAfterResponse)

--- a/Sources/imsg/RPCServer.swift
+++ b/Sources/imsg/RPCServer.swift
@@ -69,11 +69,11 @@ final class RPCServer: @unchecked Sendable {
   let bridgeEventPathUsable: @Sendable (String) -> Bool
   let bridgeEventStreamProvider: RPCBridgeEventStreamProvider
 
-  /// Confirms a caption row reached the target chat. Returns nil when the
-  /// check could not run, which must never be reported as a delivery verdict.
+  /// Reports the caption row's outcome in the target chat, including explicit
+  /// unknown and unavailable states that must not become delivery verdicts.
   typealias CaptionVerifier = (
     _ captionGUID: String, _ chatGUID: String, _ store: MessageStore?
-  ) async -> Bool?
+  ) async -> PollCaptionStatus.VerificationOutcome
 
   init(
     store: MessageStore,

--- a/Sources/imsg/RPCServer.swift
+++ b/Sources/imsg/RPCServer.swift
@@ -86,7 +86,8 @@ final class RPCServer: @unchecked Sendable {
     },
     verifyCaption: @escaping CaptionVerifier = { captionGUID, chatGUID, store in
       await PollCaptionStatus.verifyCaption(
-        captionGUID: captionGUID, chatGUID: chatGUID, store: store)
+        captionGUID: captionGUID, chatGUID: chatGUID, store: store,
+        timeout: PollCaptionStatus.rpcVerifyTimeout)
     },
     stageAttachment: @escaping AttachmentStager = MessageSender.stageAttachmentForMessagesApp,
     stageSticker: @escaping StickerStager = {
@@ -155,7 +156,8 @@ final class RPCServer: @unchecked Sendable {
     },
     verifyCaption: @escaping CaptionVerifier = { captionGUID, chatGUID, store in
       await PollCaptionStatus.verifyCaption(
-        captionGUID: captionGUID, chatGUID: chatGUID, store: store)
+        captionGUID: captionGUID, chatGUID: chatGUID, store: store,
+        timeout: PollCaptionStatus.rpcVerifyTimeout)
     },
     stageAttachment: @escaping AttachmentStager = MessageSender.stageAttachmentForMessagesApp,
     stageSticker: @escaping StickerStager = { try StickerAssetPreparer.prepare(at: $0) },

--- a/Sources/imsg/RPCServer.swift
+++ b/Sources/imsg/RPCServer.swift
@@ -55,6 +55,7 @@ final class RPCServer: @unchecked Sendable {
   let sendMessage: (MessageSendOptions) throws -> Void
   let resolveSentMessage: SentMessageResolver
   let bridgeInvoker: BridgeInvoker
+  let captionVerifier: CaptionVerifier
   let stageAttachment: AttachmentStager
   let stageSticker: StickerStager
   let prepareRichLink: RichLinkPrepare
@@ -68,6 +69,12 @@ final class RPCServer: @unchecked Sendable {
   let bridgeEventPathUsable: @Sendable (String) -> Bool
   let bridgeEventStreamProvider: RPCBridgeEventStreamProvider
 
+  /// Confirms a caption row reached the target chat. Returns nil when the
+  /// check could not run, which must never be reported as a delivery verdict.
+  typealias CaptionVerifier = (
+    _ captionGUID: String, _ chatGUID: String, _ store: MessageStore?
+  ) async -> Bool?
+
   init(
     store: MessageStore,
     verbose: Bool,
@@ -76,6 +83,10 @@ final class RPCServer: @unchecked Sendable {
     resolveSentMessage: @escaping SentMessageResolver = RPCServer.resolveSentMessage,
     invokeBridge: @escaping BridgeInvoker = { action, params in
       try await IMsgBridgeClient.shared.invokeWithoutLaunching(action: action, params: params)
+    },
+    verifyCaption: @escaping CaptionVerifier = { captionGUID, chatGUID, store in
+      await PollCaptionStatus.verifyCaption(
+        captionGUID: captionGUID, chatGUID: chatGUID, store: store)
     },
     stageAttachment: @escaping AttachmentStager = MessageSender.stageAttachmentForMessagesApp,
     stageSticker: @escaping StickerStager = {
@@ -117,6 +128,7 @@ final class RPCServer: @unchecked Sendable {
     self.sendMessage = sendMessage
     self.resolveSentMessage = resolveSentMessage
     self.bridgeInvoker = invokeBridge
+    self.captionVerifier = verifyCaption
     self.stageAttachment = stageAttachment
     self.stageSticker = stageSticker
     self.prepareRichLink = prepareRichLink
@@ -140,6 +152,10 @@ final class RPCServer: @unchecked Sendable {
     resolveSentMessage: @escaping SentMessageResolver = RPCServer.resolveSentMessage,
     invokeBridge: @escaping BridgeInvoker = { action, params in
       try await IMsgBridgeClient.shared.invokeWithoutLaunching(action: action, params: params)
+    },
+    verifyCaption: @escaping CaptionVerifier = { captionGUID, chatGUID, store in
+      await PollCaptionStatus.verifyCaption(
+        captionGUID: captionGUID, chatGUID: chatGUID, store: store)
     },
     stageAttachment: @escaping AttachmentStager = MessageSender.stageAttachmentForMessagesApp,
     stageSticker: @escaping StickerStager = { try StickerAssetPreparer.prepare(at: $0) },
@@ -177,6 +193,7 @@ final class RPCServer: @unchecked Sendable {
     self.sendMessage = sendMessage
     self.resolveSentMessage = resolveSentMessage
     self.bridgeInvoker = invokeBridge
+    self.captionVerifier = verifyCaption
     self.stageAttachment = stageAttachment
     self.stageSticker = stageSticker
     self.prepareRichLink = prepareRichLink

--- a/Tests/imsgTests/BridgeRichCommandTests.swift
+++ b/Tests/imsgTests/BridgeRichCommandTests.swift
@@ -344,7 +344,7 @@ func pollCommandSendInvokesPollBridge() async throws {
         return ["messageGuid": "poll-guid"]
       },
       // Stubbed: this test asserts bridge wiring, not row verification.
-      verifyCaption: { _ in true }
+      verifyCaption: { _ in .delivered }
     )
   }
 
@@ -386,7 +386,7 @@ func pollCommandSendUsesCommentOverrideWithoutPollGuid() async throws {
         return [:]
       },
       // Stubbed: this test asserts bridge wiring, not row verification.
-      verifyCaption: { _ in true }
+      verifyCaption: { _ in .delivered }
     )
   }
 
@@ -483,7 +483,7 @@ func pollCommandSendResolvesChatID() async throws {
         return ["messageGuid": "poll-guid"]
       },
       // Stubbed: this test asserts bridge wiring, not row verification.
-      verifyCaption: { _ in true }
+      verifyCaption: { _ in .delivered }
     )
   }
 

--- a/Tests/imsgTests/BridgeRichCommandTests.swift
+++ b/Tests/imsgTests/BridgeRichCommandTests.swift
@@ -342,7 +342,9 @@ func pollCommandSendInvokesPollBridge() async throws {
       invokeBridge: { action, params in
         calls.append((action, params))
         return ["messageGuid": "poll-guid"]
-      }
+      },
+      // Stubbed: this test asserts bridge wiring, not row verification.
+      verifyCaption: { _ in true }
     )
   }
 
@@ -382,7 +384,9 @@ func pollCommandSendUsesCommentOverrideWithoutPollGuid() async throws {
       invokeBridge: { action, params in
         calls.append((action, params))
         return [:]
-      }
+      },
+      // Stubbed: this test asserts bridge wiring, not row verification.
+      verifyCaption: { _ in true }
     )
   }
 
@@ -477,7 +481,9 @@ func pollCommandSendResolvesChatID() async throws {
       invokeBridge: { _, params in
         capturedParams = params
         return ["messageGuid": "poll-guid"]
-      }
+      },
+      // Stubbed: this test asserts bridge wiring, not row verification.
+      verifyCaption: { _ in true }
     )
   }
 

--- a/Tests/imsgTests/PollCaptionStatusTests.swift
+++ b/Tests/imsgTests/PollCaptionStatusTests.swift
@@ -73,6 +73,7 @@ func pollSendReportsCaptionDeliveryWhenItLands() async throws {
   #expect(calls == 2)
   #expect(json["messageGuid"] as? String == "poll-guid")
   let comment = try #require(json["comment"] as? [String: Any])
+  #expect(comment["message_guid"] as? String == "caption-guid")
   #expect(comment["requested"] as? Bool == true)
   #expect(comment["sent"] as? Bool == true)
   #expect(comment["verified"] as? Bool == true)
@@ -91,6 +92,7 @@ func pollSendReportsUnknownWhenCaptionVerificationExpires() async throws {
   #expect(calls == 2)
   #expect(json["messageGuid"] as? String == "poll-guid")
   let comment = try #require(json["comment"] as? [String: Any])
+  #expect(comment["message_guid"] as? String == "caption-guid")
   #expect(comment["requested"] as? Bool == true)
   #expect(comment["sent"] is NSNull)
   #expect(comment["verified"] as? Bool == false)
@@ -270,29 +272,8 @@ func verifyCaptionDoesNotGuessWithoutAGuidToLookFor() async throws {
   #expect(result == .unavailable)
 }
 
-@Test
-func captionOutcomeRejectsARowMessagesRecordedAsFailed() async throws {
-  // A row existing is not delivery. Messages writes a row for a failed send
-  // too, and calling that verified is the exact false success this whole
-  // status object exists to remove.
-  #expect(PollCaptionStatus.captionOutcome(for: .failed) == .failed)
-}
-
-@Test
-func captionOutcomeKeepsWaitingWhileTheSendIsPending() async throws {
-  // unknown means "no verdict yet" — the caller keeps polling until the row flips
-  // or the deadline passes, rather than banking an answer it does not have.
-  #expect(PollCaptionStatus.captionOutcome(for: .pending) == .unknown)
-}
-
-@Test
-func captionOutcomeRequiresDeliveredRatherThanLocallySent() async throws {
-  #expect(PollCaptionStatus.captionOutcome(for: .sent) == .unknown)
-  #expect(PollCaptionStatus.captionOutcome(for: .delivered) == .delivered)
-}
-
-@Test
-func verifyCaptionToleratesGuidCasingBetweenBridgeAndDatabase() async throws {
+@Test(arguments: [false, true])
+func verifyCaptionToleratesGuidCasingBetweenBridgeAndDatabase(wrongChat: Bool) async throws {
   // messageSendStatus matches COLLATE NOCASE but messageBelongsToChat does
   // not, so a bridge GUID whose casing differs from the stored row must not
   // read back as a missing caption.
@@ -311,11 +292,11 @@ func verifyCaptionToleratesGuidCasingBetweenBridgeAndDatabase() async throws {
 
   let result = await PollCaptionStatus.verifyCaption(
     captionGUID: "caption-guid",
-    chatGUID: "iMessage;-;+123",
+    chatGUID: wrongChat ? "iMessage;-;+456" : "iMessage;-;+123",
     store: store,
     timeout: 0.5
   )
-  #expect(result == .delivered)
+  #expect(result == (wrongChat ? .unknown : .delivered))
 }
 
 @Test
@@ -435,6 +416,7 @@ func rpcPollSendReportsCaptionDeliveryWhenItLands() async throws {
 
   #expect(result["ok"] as? Bool == true)
   let comment = try #require(result["comment"] as? [String: Any])
+  #expect(comment["message_guid"] as? String == "caption-guid")
   #expect(comment["requested"] as? Bool == true)
   #expect(comment["sent"] as? Bool == true)
   #expect(comment["verified"] as? Bool == true)
@@ -448,6 +430,7 @@ func rpcPollSendReportsUnknownWhenCaptionVerificationExpires() async throws {
   #expect(result["ok"] as? Bool == true)
   // …but a late caption may still arrive, so delivery remains unknown.
   let comment = try #require(result["comment"] as? [String: Any])
+  #expect(comment["message_guid"] as? String == "caption-guid")
   #expect(comment["sent"] is NSNull)
   #expect(comment["verified"] as? Bool == false)
   #expect(comment["disposition"] as? String == "may_have_completed")

--- a/Tests/imsgTests/PollCaptionStatusTests.swift
+++ b/Tests/imsgTests/PollCaptionStatusTests.swift
@@ -34,7 +34,8 @@ private func pollSendValues(
 /// returning the decoded JSON object the command emitted.
 private func runPollSend(
   values: ParsedValues,
-  captionError: Error? = nil
+  captionError: Error? = nil,
+  verified: Bool? = true
 ) async throws -> (json: [String: Any], calls: Int, output: String) {
   let runtime = RuntimeOptions(parsedValues: values)
   var calls = 0
@@ -47,8 +48,9 @@ private func runPollSend(
         if action == .sendMessage, let captionError {
           throw captionError
         }
-        return ["messageGuid": "poll-guid"]
-      }
+        return ["messageGuid": action == .sendMessage ? "caption-guid" : "poll-guid"]
+      },
+      verifyCaption: { _ in verified }
     )
   }
   let line = output.split(separator: "\n").last.map(String.init) ?? ""
@@ -66,6 +68,41 @@ func pollSendReportsCaptionDeliveryWhenItLands() async throws {
   let comment = try #require(json["comment"] as? [String: Any])
   #expect(comment["requested"] as? Bool == true)
   #expect(comment["sent"] as? Bool == true)
+  #expect(comment["verified"] as? Bool == true)
+  #expect(comment["error"] == nil)
+}
+
+@Test
+func pollSendWillNotClaimDeliveryWhenTheCaptionRowNeverAppears() async throws {
+  // The bridge acknowledged the send, but no caption row reached the chat —
+  // the recipient is looking at a question-less balloon, so `sent` must be
+  // false even though nothing threw.
+  let (json, calls, _) = try await runPollSend(
+    values: pollSendValues(flags: ["jsonOutput"]),
+    verified: false
+  )
+
+  #expect(calls == 2)
+  #expect(json["messageGuid"] as? String == "poll-guid")
+  let comment = try #require(json["comment"] as? [String: Any])
+  #expect(comment["requested"] as? Bool == true)
+  #expect(comment["sent"] as? Bool == false)
+  #expect(comment["verified"] as? Bool == false)
+  #expect(comment["disposition"] as? String == "may_have_completed")
+  #expect(comment["retry_safe"] as? Bool == false)
+}
+
+@Test
+func pollSendOmitsVerifiedWhenTheCheckCannotRun() async throws {
+  // No readable database: we did not look, so we claim neither outcome.
+  let (json, _, _) = try await runPollSend(
+    values: pollSendValues(flags: ["jsonOutput"]),
+    verified: nil
+  )
+
+  let comment = try #require(json["comment"] as? [String: Any])
+  #expect(comment["sent"] as? Bool == true)
+  #expect(comment["verified"] == nil)
   #expect(comment["error"] == nil)
 }
 
@@ -143,7 +180,8 @@ func pollSendHumanSummaryStaysQuietWhenCaptionLands() async throws {
 /// Runs `poll.send` over the RPC server, returning the response result object.
 private func runRPCPollSend(
   suppressComment: Bool = false,
-  captionError: Error? = nil
+  captionError: Error? = nil,
+  verified: Bool? = true
 ) async throws -> [String: Any] {
   let store = try CommandTestDatabase.makeStoreForRPC()
   let output = TestRPCOutput()
@@ -155,8 +193,9 @@ private func runRPCPollSend(
       if action == .sendMessage, let captionError {
         throw captionError
       }
-      return ["messageGuid": "poll-guid"]
-    }
+      return ["messageGuid": action == .sendMessage ? "caption-guid" : "poll-guid"]
+    },
+    verifyCaption: { _, _, _ in verified }
   )
 
   let suppress = suppressComment ? #","suppress_comment":true"# : ""
@@ -178,6 +217,20 @@ func rpcPollSendReportsCaptionDeliveryWhenItLands() async throws {
   let comment = try #require(result["comment"] as? [String: Any])
   #expect(comment["requested"] as? Bool == true)
   #expect(comment["sent"] as? Bool == true)
+  #expect(comment["verified"] as? Bool == true)
+}
+
+@Test
+func rpcPollSendWillNotClaimDeliveryWhenTheCaptionRowNeverAppears() async throws {
+  let result = try await runRPCPollSend(verified: false)
+
+  // The balloon landed, so the send is still a success…
+  #expect(result["ok"] as? Bool == true)
+  // …but the question is not on screen, and the caller has to be told.
+  let comment = try #require(result["comment"] as? [String: Any])
+  #expect(comment["sent"] as? Bool == false)
+  #expect(comment["verified"] as? Bool == false)
+  #expect(comment["disposition"] as? String == "may_have_completed")
 }
 
 @Test

--- a/Tests/imsgTests/PollCaptionStatusTests.swift
+++ b/Tests/imsgTests/PollCaptionStatusTests.swift
@@ -195,6 +195,27 @@ func verifyCaptionDoesNotGuessWithoutAGuidToLookFor() async throws {
 }
 
 @Test
+func captionOutcomeRejectsARowMessagesRecordedAsFailed() async throws {
+  // A row existing is not delivery. Messages writes a row for a failed send
+  // too, and calling that verified is the exact false success this whole
+  // status object exists to remove.
+  #expect(PollCaptionStatus.captionOutcome(for: .failed) == false)
+}
+
+@Test
+func captionOutcomeKeepsWaitingWhileTheSendIsPending() async throws {
+  // nil means "no verdict yet" — the caller keeps polling until the row flips
+  // or the deadline passes, rather than banking an answer it does not have.
+  #expect(PollCaptionStatus.captionOutcome(for: .pending) == nil)
+}
+
+@Test
+func captionOutcomeAcceptsSentAndDeliveredRows() async throws {
+  #expect(PollCaptionStatus.captionOutcome(for: .sent) == true)
+  #expect(PollCaptionStatus.captionOutcome(for: .delivered) == true)
+}
+
+@Test
 func verifyCaptionReportsAnAbsentRowAsUndelivered() async throws {
   let store = try CommandTestDatabase.makeStoreForRPC()
   let result = await PollCaptionStatus.verifyCaption(

--- a/Tests/imsgTests/PollCaptionStatusTests.swift
+++ b/Tests/imsgTests/PollCaptionStatusTests.swift
@@ -216,6 +216,31 @@ func captionOutcomeAcceptsSentAndDeliveredRows() async throws {
 }
 
 @Test
+func verifyCaptionToleratesGuidCasingBetweenBridgeAndDatabase() async throws {
+  // messageSendStatus matches COLLATE NOCASE but messageBelongsToChat does
+  // not, so a bridge GUID whose casing differs from the stored row must not
+  // read back as a missing caption.
+  let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
+  _ = try store.withConnection { db in
+    try db.run("ALTER TABLE message ADD COLUMN guid TEXT")
+    try db.run("ALTER TABLE message ADD COLUMN is_sent INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN error INTEGER")
+    // The row stores the GUID uppercased; the bridge will hand us lowercase.
+    try db.run(
+      "UPDATE message SET guid = ?, is_sent = 1, error = 0 WHERE ROWID = 5", "CAPTION-GUID")
+    try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 5)")
+  }
+
+  let result = await PollCaptionStatus.verifyCaption(
+    captionGUID: "caption-guid",
+    chatGUID: "iMessage;-;+123",
+    store: store,
+    timeout: 0.5
+  )
+  #expect(result == true)
+}
+
+@Test
 func verifyCaptionReportsAnAbsentRowAsUndelivered() async throws {
   let store = try CommandTestDatabase.makeStoreForRPC()
   let result = await PollCaptionStatus.verifyCaption(

--- a/Tests/imsgTests/PollCaptionStatusTests.swift
+++ b/Tests/imsgTests/PollCaptionStatusTests.swift
@@ -1,0 +1,206 @@
+import Commander
+import Foundation
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+// A poll's question is only ever visible via the caption message imsg sends
+// after the balloon, so a dropped caption leaves a question-less poll on screen.
+// These tests pin the contract that `poll send` reports that outcome instead of
+// returning a bare success the caller cannot distinguish from a complete send.
+
+private let captionFailure = DeliveryFailure(
+  disposition: .mayHaveCompleted,
+  transport: .bridgeV2,
+  operation: "send_message",
+  detail: "The bridge response deadline expired."
+)
+
+private func pollSendValues(
+  extraOptions: [String: [String]] = [:],
+  flags: Set<String> = []
+) -> ParsedValues {
+  var options: [String: [String]] = [
+    "chat": ["iMessage;-;+15551234567"],
+    "question": ["Dinner?"],
+    "option": ["Pizza", "Sushi"],
+  ]
+  for (key, value) in extraOptions { options[key] = value }
+  return ParsedValues(positional: ["send"], options: options, flags: flags)
+}
+
+/// Runs `poll send` with a bridge whose caption (second) call optionally throws,
+/// returning the decoded JSON object the command emitted.
+private func runPollSend(
+  values: ParsedValues,
+  captionError: Error? = nil
+) async throws -> (json: [String: Any], calls: Int, output: String) {
+  let runtime = RuntimeOptions(parsedValues: values)
+  var calls = 0
+  let (output, _) = try await StdoutCapture.capture {
+    try await PollCommand.run(
+      values: values,
+      runtime: runtime,
+      invokeBridge: { action, _ in
+        calls += 1
+        if action == .sendMessage, let captionError {
+          throw captionError
+        }
+        return ["messageGuid": "poll-guid"]
+      }
+    )
+  }
+  let line = output.split(separator: "\n").last.map(String.init) ?? ""
+  let json =
+    (try? JSONSerialization.jsonObject(with: Data(line.utf8))) as? [String: Any] ?? [:]
+  return (json, calls, output)
+}
+
+@Test
+func pollSendReportsCaptionDeliveryWhenItLands() async throws {
+  let (json, calls, _) = try await runPollSend(values: pollSendValues(flags: ["jsonOutput"]))
+
+  #expect(calls == 2)
+  #expect(json["messageGuid"] as? String == "poll-guid")
+  let comment = try #require(json["comment"] as? [String: Any])
+  #expect(comment["requested"] as? Bool == true)
+  #expect(comment["sent"] as? Bool == true)
+  #expect(comment["error"] == nil)
+}
+
+@Test
+func pollSendReportsCaptionFailureInsteadOfSwallowingIt() async throws {
+  let (json, calls, _) = try await runPollSend(
+    values: pollSendValues(flags: ["jsonOutput"]),
+    captionError: captionFailure
+  )
+
+  // The poll itself still succeeded, so the guid survives and the command does
+  // not throw — re-sending the pair would duplicate the balloon.
+  #expect(calls == 2)
+  #expect(json["messageGuid"] as? String == "poll-guid")
+
+  // …but the caller can now see that the question never became visible.
+  let comment = try #require(json["comment"] as? [String: Any])
+  #expect(comment["requested"] as? Bool == true)
+  #expect(comment["sent"] as? Bool == false)
+  #expect(comment["disposition"] as? String == "may_have_completed")
+  #expect(comment["retry_safe"] as? Bool == false)
+  let error = try #require(comment["error"] as? String)
+  #expect(error.contains("The bridge response deadline expired."))
+}
+
+@Test
+func pollSendReportsCaptionFailureForUntypedErrors() async throws {
+  struct Boom: Error, CustomStringConvertible { var description: String { "boom" } }
+  let (json, _, _) = try await runPollSend(
+    values: pollSendValues(flags: ["jsonOutput"]),
+    captionError: Boom()
+  )
+
+  let comment = try #require(json["comment"] as? [String: Any])
+  #expect(comment["sent"] as? Bool == false)
+  #expect(comment["error"] as? String == "boom")
+  // No transport disposition to report when the error is not a DeliveryFailure.
+  #expect(comment["disposition"] == nil)
+}
+
+@Test
+func pollSendMarksSuppressedCaptionAsNotRequested() async throws {
+  let (json, calls, _) = try await runPollSend(
+    values: pollSendValues(flags: ["jsonOutput", "noComment"])
+  )
+
+  #expect(calls == 1)
+  let comment = try #require(json["comment"] as? [String: Any])
+  #expect(comment["requested"] as? Bool == false)
+  #expect(comment["sent"] as? Bool == false)
+  #expect(comment["error"] == nil)
+}
+
+@Test
+func pollSendHumanSummaryCallsOutAMissingCaption() async throws {
+  let (_, _, output) = try await runPollSend(
+    values: pollSendValues(),
+    captionError: captionFailure
+  )
+
+  #expect(output.contains("poll: sent (guid=poll-guid)"))
+  #expect(output.contains("caption NOT delivered"))
+}
+
+@Test
+func pollSendHumanSummaryStaysQuietWhenCaptionLands() async throws {
+  let (_, _, output) = try await runPollSend(values: pollSendValues())
+
+  #expect(output.contains("poll: sent (guid=poll-guid)"))
+  #expect(!output.contains("caption NOT delivered"))
+}
+
+// MARK: - RPC surface
+
+/// Runs `poll.send` over the RPC server, returning the response result object.
+private func runRPCPollSend(
+  suppressComment: Bool = false,
+  captionError: Error? = nil
+) async throws -> [String: Any] {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let output = TestRPCOutput()
+  let server = RPCServer(
+    store: store,
+    verbose: false,
+    output: output,
+    invokeBridge: { action, _ in
+      if action == .sendMessage, let captionError {
+        throw captionError
+      }
+      return ["messageGuid": "poll-guid"]
+    }
+  )
+
+  let suppress = suppressComment ? #","suppress_comment":true"# : ""
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":"poll","method":"poll.send","params":{"#
+      + #""chat_id":1,"question":"Dinner?","options":["Pizza","Sushi"]"#
+      + suppress + #"}}"#
+  )
+
+  let response = try #require(output.responses.last)
+  return try #require(response["result"] as? [String: Any])
+}
+
+@Test
+func rpcPollSendReportsCaptionDeliveryWhenItLands() async throws {
+  let result = try await runRPCPollSend()
+
+  #expect(result["ok"] as? Bool == true)
+  let comment = try #require(result["comment"] as? [String: Any])
+  #expect(comment["requested"] as? Bool == true)
+  #expect(comment["sent"] as? Bool == true)
+}
+
+@Test
+func rpcPollSendReportsCaptionFailureWithoutFailingTheSend() async throws {
+  let result = try await runRPCPollSend(captionError: captionFailure)
+
+  // The balloon landed, so `ok` must stay true — a caller that retried on
+  // `ok: false` would post a second poll.
+  #expect(result["ok"] as? Bool == true)
+  #expect(result["message_id"] as? String == "poll-guid")
+
+  let comment = try #require(result["comment"] as? [String: Any])
+  #expect(comment["requested"] as? Bool == true)
+  #expect(comment["sent"] as? Bool == false)
+  #expect(comment["disposition"] as? String == "may_have_completed")
+  #expect(comment["retry_safe"] as? Bool == false)
+}
+
+@Test
+func rpcPollSendMarksSuppressedCaptionAsNotRequested() async throws {
+  let result = try await runRPCPollSend(suppressComment: true)
+
+  let comment = try #require(result["comment"] as? [String: Any])
+  #expect(comment["requested"] as? Bool == false)
+  #expect(comment["sent"] as? Bool == false)
+}

--- a/Tests/imsgTests/PollCaptionStatusTests.swift
+++ b/Tests/imsgTests/PollCaptionStatusTests.swift
@@ -17,6 +17,13 @@ private let captionFailure = DeliveryFailure(
   detail: "The bridge response deadline expired."
 )
 
+private let retrySafeCaptionFailure = DeliveryFailure(
+  disposition: .notStarted,
+  transport: .bridgeV2,
+  operation: "send_message",
+  detail: "The bridge rejected the request before dispatch."
+)
+
 private func pollSendValues(
   extraOptions: [String: [String]] = [:],
   flags: Set<String> = []
@@ -35,7 +42,7 @@ private func pollSendValues(
 private func runPollSend(
   values: ParsedValues,
   captionError: Error? = nil,
-  verified: Bool? = true
+  verification: PollCaptionStatus.VerificationOutcome = .delivered
 ) async throws -> (json: [String: Any], calls: Int, output: String) {
   let runtime = RuntimeOptions(parsedValues: values)
   var calls = 0
@@ -50,7 +57,7 @@ private func runPollSend(
         }
         return ["messageGuid": action == .sendMessage ? "caption-guid" : "poll-guid"]
       },
-      verifyCaption: { _ in verified }
+      verifyCaption: { _ in verification }
     )
   }
   let line = output.split(separator: "\n").last.map(String.init) ?? ""
@@ -73,23 +80,35 @@ func pollSendReportsCaptionDeliveryWhenItLands() async throws {
 }
 
 @Test
-func pollSendWillNotClaimDeliveryWhenTheCaptionRowNeverAppears() async throws {
-  // The bridge acknowledged the send, but no caption row reached the chat —
-  // the recipient is looking at a question-less balloon, so `sent` must be
-  // false even though nothing threw.
+func pollSendReportsUnknownWhenCaptionVerificationExpires() async throws {
+  // The bridge acknowledged the send, but the row was not confirmed before
+  // the deadline. It may still arrive, so this must not become `sent: false`.
   let (json, calls, _) = try await runPollSend(
     values: pollSendValues(flags: ["jsonOutput"]),
-    verified: false
+    verification: .unknown
   )
 
   #expect(calls == 2)
   #expect(json["messageGuid"] as? String == "poll-guid")
   let comment = try #require(json["comment"] as? [String: Any])
   #expect(comment["requested"] as? Bool == true)
-  #expect(comment["sent"] as? Bool == false)
+  #expect(comment["sent"] is NSNull)
   #expect(comment["verified"] as? Bool == false)
   #expect(comment["disposition"] as? String == "may_have_completed")
   #expect(comment["retry_safe"] as? Bool == false)
+}
+
+@Test
+func pollSendReportsRecordedCaptionFailureWithoutInferringRetrySafety() async throws {
+  let (json, _, _) = try await runPollSend(
+    values: pollSendValues(flags: ["jsonOutput"]),
+    verification: .failed
+  )
+
+  let comment = try #require(json["comment"] as? [String: Any])
+  #expect(comment["sent"] as? Bool == false)
+  #expect(comment["verified"] as? Bool == false)
+  #expect(comment["retry_safe"] == nil)
 }
 
 @Test
@@ -97,11 +116,11 @@ func pollSendOmitsVerifiedWhenTheCheckCannotRun() async throws {
   // No readable database: we did not look, so we claim neither outcome.
   let (json, _, _) = try await runPollSend(
     values: pollSendValues(flags: ["jsonOutput"]),
-    verified: nil
+    verification: .unavailable
   )
 
   let comment = try #require(json["comment"] as? [String: Any])
-  #expect(comment["sent"] as? Bool == true)
+  #expect(comment["sent"] is NSNull)
   #expect(comment["verified"] == nil)
   #expect(comment["error"] == nil)
 }
@@ -118,10 +137,10 @@ func pollSendReportsCaptionFailureInsteadOfSwallowingIt() async throws {
   #expect(calls == 2)
   #expect(json["messageGuid"] as? String == "poll-guid")
 
-  // …but the caller can now see that the question never became visible.
+  // …but the transport cannot prove whether the caption eventually landed.
   let comment = try #require(json["comment"] as? [String: Any])
   #expect(comment["requested"] as? Bool == true)
-  #expect(comment["sent"] as? Bool == false)
+  #expect(comment["sent"] is NSNull)
   #expect(comment["disposition"] as? String == "may_have_completed")
   #expect(comment["retry_safe"] as? Bool == false)
   let error = try #require(comment["error"] as? String)
@@ -137,10 +156,42 @@ func pollSendReportsCaptionFailureForUntypedErrors() async throws {
   )
 
   let comment = try #require(json["comment"] as? [String: Any])
-  #expect(comment["sent"] as? Bool == false)
+  #expect(comment["sent"] is NSNull)
   #expect(comment["error"] as? String == "boom")
   // No transport disposition to report when the error is not a DeliveryFailure.
   #expect(comment["disposition"] == nil)
+}
+
+@Test
+func pollSendReportsNotStartedCaptionAsRetrySafe() async throws {
+  let (json, _, _) = try await runPollSend(
+    values: pollSendValues(flags: ["jsonOutput"]),
+    captionError: retrySafeCaptionFailure
+  )
+
+  let comment = try #require(json["comment"] as? [String: Any])
+  #expect(comment["sent"] as? Bool == false)
+  #expect(comment["disposition"] as? String == "not_started")
+  #expect(comment["retry_safe"] as? Bool == true)
+}
+
+@Test
+func pollSendReportsStillInFlightCaptionAsUnknown() async throws {
+  let failure = DeliveryFailure(
+    disposition: .stillInFlight,
+    transport: .bridgeV2,
+    operation: "send_message",
+    detail: "The bridge still owns the request."
+  )
+  let (json, _, _) = try await runPollSend(
+    values: pollSendValues(flags: ["jsonOutput"]),
+    captionError: failure
+  )
+
+  let comment = try #require(json["comment"] as? [String: Any])
+  #expect(comment["sent"] is NSNull)
+  #expect(comment["disposition"] as? String == "still_in_flight")
+  #expect(comment["retry_safe"] as? Bool == false)
 }
 
 @Test
@@ -157,14 +208,39 @@ func pollSendMarksSuppressedCaptionAsNotRequested() async throws {
 }
 
 @Test
-func pollSendHumanSummaryCallsOutAMissingCaption() async throws {
+func pollSendHumanSummaryPreservesUnknownDelivery() async throws {
   let (_, _, output) = try await runPollSend(
     values: pollSendValues(),
     captionError: captionFailure
   )
 
   #expect(output.contains("poll: sent (guid=poll-guid)"))
+  #expect(output.contains("caption delivery UNKNOWN"))
+  #expect(output.contains("do not retry automatically"))
+  #expect(!output.contains("caption NOT delivered"))
+}
+
+@Test
+func pollSendHumanSummaryAdvisesRetryOnlyWhenSafe() async throws {
+  let (_, _, output) = try await runPollSend(
+    values: pollSendValues(),
+    captionError: retrySafeCaptionFailure
+  )
+
   #expect(output.contains("caption NOT delivered"))
+  #expect(output.contains("re-send the caption only, never the poll"))
+}
+
+@Test
+func pollSendHumanSummaryDoesNotInferRetrySafetyFromRecordedFailure() async throws {
+  let (_, _, output) = try await runPollSend(
+    values: pollSendValues(),
+    verification: .failed
+  )
+
+  #expect(output.contains("caption NOT delivered"))
+  #expect(output.contains("automatic retry is not known to be safe"))
+  #expect(!output.contains("re-send the caption only"))
 }
 
 @Test
@@ -183,7 +259,7 @@ func verifyCaptionDoesNotGuessWithoutAStore() async throws {
   // negative verdict, or callers read "we did not look" as "it never arrived".
   let result = await PollCaptionStatus.verifyCaption(
     captionGUID: "caption-guid", chatGUID: "iMessage;-;+15551234567", store: nil)
-  #expect(result == nil)
+  #expect(result == .unavailable)
 }
 
 @Test
@@ -191,7 +267,7 @@ func verifyCaptionDoesNotGuessWithoutAGuidToLookFor() async throws {
   let store = try CommandTestDatabase.makeStoreForRPC()
   let result = await PollCaptionStatus.verifyCaption(
     captionGUID: "", chatGUID: "iMessage;-;+15551234567", store: store)
-  #expect(result == nil)
+  #expect(result == .unavailable)
 }
 
 @Test
@@ -199,20 +275,20 @@ func captionOutcomeRejectsARowMessagesRecordedAsFailed() async throws {
   // A row existing is not delivery. Messages writes a row for a failed send
   // too, and calling that verified is the exact false success this whole
   // status object exists to remove.
-  #expect(PollCaptionStatus.captionOutcome(for: .failed) == false)
+  #expect(PollCaptionStatus.captionOutcome(for: .failed) == .failed)
 }
 
 @Test
 func captionOutcomeKeepsWaitingWhileTheSendIsPending() async throws {
-  // nil means "no verdict yet" — the caller keeps polling until the row flips
+  // unknown means "no verdict yet" — the caller keeps polling until the row flips
   // or the deadline passes, rather than banking an answer it does not have.
-  #expect(PollCaptionStatus.captionOutcome(for: .pending) == nil)
+  #expect(PollCaptionStatus.captionOutcome(for: .pending) == .unknown)
 }
 
 @Test
 func captionOutcomeAcceptsSentAndDeliveredRows() async throws {
-  #expect(PollCaptionStatus.captionOutcome(for: .sent) == true)
-  #expect(PollCaptionStatus.captionOutcome(for: .delivered) == true)
+  #expect(PollCaptionStatus.captionOutcome(for: .sent) == .delivered)
+  #expect(PollCaptionStatus.captionOutcome(for: .delivered) == .delivered)
 }
 
 @Test
@@ -237,11 +313,11 @@ func verifyCaptionToleratesGuidCasingBetweenBridgeAndDatabase() async throws {
     store: store,
     timeout: 0.5
   )
-  #expect(result == true)
+  #expect(result == .delivered)
 }
 
 @Test
-func verifyCaptionReportsAnAbsentRowAsUndelivered() async throws {
+func verifyCaptionReportsAnAbsentRowAsUnknown() async throws {
   let store = try CommandTestDatabase.makeStoreForRPC()
   let result = await PollCaptionStatus.verifyCaption(
     captionGUID: "never-sent-guid",
@@ -249,7 +325,49 @@ func verifyCaptionReportsAnAbsentRowAsUndelivered() async throws {
     store: store,
     timeout: 0.2
   )
-  #expect(result == false)
+  #expect(result == .unknown)
+}
+
+@Test
+func verifyCaptionReportsARecordedFailureSeparatelyFromTimeout() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
+  _ = try store.withConnection { db in
+    try db.run("ALTER TABLE message ADD COLUMN guid TEXT")
+    try db.run("ALTER TABLE message ADD COLUMN is_sent INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN error INTEGER")
+    try db.run(
+      "UPDATE message SET guid = ?, is_sent = 0, error = 1 WHERE ROWID = 5", "FAILED-GUID")
+    try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 5)")
+  }
+
+  let result = await PollCaptionStatus.verifyCaption(
+    captionGUID: "failed-guid",
+    chatGUID: "iMessage;-;+123",
+    store: store,
+    timeout: 0.5
+  )
+  #expect(result == .failed)
+}
+
+@Test
+func verifyCaptionReportsAPendingRowAtDeadlineAsUnknown() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
+  _ = try store.withConnection { db in
+    try db.run("ALTER TABLE message ADD COLUMN guid TEXT")
+    try db.run("ALTER TABLE message ADD COLUMN is_sent INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN error INTEGER")
+    try db.run(
+      "UPDATE message SET guid = ?, is_sent = 0, error = 0 WHERE ROWID = 5", "PENDING-GUID")
+    try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 5)")
+  }
+
+  let result = await PollCaptionStatus.verifyCaption(
+    captionGUID: "pending-guid",
+    chatGUID: "iMessage;-;+123",
+    store: store,
+    timeout: 0.2
+  )
+  #expect(result == .unknown)
 }
 
 // MARK: - RPC surface
@@ -258,7 +376,7 @@ func verifyCaptionReportsAnAbsentRowAsUndelivered() async throws {
 private func runRPCPollSend(
   suppressComment: Bool = false,
   captionError: Error? = nil,
-  verified: Bool? = true
+  verification: PollCaptionStatus.VerificationOutcome = .delivered
 ) async throws -> [String: Any] {
   let store = try CommandTestDatabase.makeStoreForRPC()
   let output = TestRPCOutput()
@@ -272,7 +390,7 @@ private func runRPCPollSend(
       }
       return ["messageGuid": action == .sendMessage ? "caption-guid" : "poll-guid"]
     },
-    verifyCaption: { _, _, _ in verified }
+    verifyCaption: { _, _, _ in verification }
   )
 
   let suppress = suppressComment ? #","suppress_comment":true"# : ""
@@ -298,16 +416,26 @@ func rpcPollSendReportsCaptionDeliveryWhenItLands() async throws {
 }
 
 @Test
-func rpcPollSendWillNotClaimDeliveryWhenTheCaptionRowNeverAppears() async throws {
-  let result = try await runRPCPollSend(verified: false)
+func rpcPollSendReportsUnknownWhenCaptionVerificationExpires() async throws {
+  let result = try await runRPCPollSend(verification: .unknown)
 
   // The balloon landed, so the send is still a success…
   #expect(result["ok"] as? Bool == true)
-  // …but the question is not on screen, and the caller has to be told.
+  // …but a late caption may still arrive, so delivery remains unknown.
+  let comment = try #require(result["comment"] as? [String: Any])
+  #expect(comment["sent"] is NSNull)
+  #expect(comment["verified"] as? Bool == false)
+  #expect(comment["disposition"] as? String == "may_have_completed")
+}
+
+@Test
+func rpcPollSendReportsRecordedCaptionFailureWithoutInferringRetrySafety() async throws {
+  let result = try await runRPCPollSend(verification: .failed)
+
   let comment = try #require(result["comment"] as? [String: Any])
   #expect(comment["sent"] as? Bool == false)
   #expect(comment["verified"] as? Bool == false)
-  #expect(comment["disposition"] as? String == "may_have_completed")
+  #expect(comment["retry_safe"] == nil)
 }
 
 @Test
@@ -321,9 +449,19 @@ func rpcPollSendReportsCaptionFailureWithoutFailingTheSend() async throws {
 
   let comment = try #require(result["comment"] as? [String: Any])
   #expect(comment["requested"] as? Bool == true)
-  #expect(comment["sent"] as? Bool == false)
+  #expect(comment["sent"] is NSNull)
   #expect(comment["disposition"] as? String == "may_have_completed")
   #expect(comment["retry_safe"] as? Bool == false)
+}
+
+@Test
+func rpcPollSendReportsRetrySafeCaptionFailure() async throws {
+  let result = try await runRPCPollSend(captionError: retrySafeCaptionFailure)
+
+  let comment = try #require(result["comment"] as? [String: Any])
+  #expect(comment["sent"] as? Bool == false)
+  #expect(comment["disposition"] as? String == "not_started")
+  #expect(comment["retry_safe"] as? Bool == true)
 }
 
 @Test

--- a/Tests/imsgTests/PollCaptionStatusTests.swift
+++ b/Tests/imsgTests/PollCaptionStatusTests.swift
@@ -286,8 +286,8 @@ func captionOutcomeKeepsWaitingWhileTheSendIsPending() async throws {
 }
 
 @Test
-func captionOutcomeAcceptsSentAndDeliveredRows() async throws {
-  #expect(PollCaptionStatus.captionOutcome(for: .sent) == .delivered)
+func captionOutcomeRequiresDeliveredRatherThanLocallySent() async throws {
+  #expect(PollCaptionStatus.captionOutcome(for: .sent) == .unknown)
   #expect(PollCaptionStatus.captionOutcome(for: .delivered) == .delivered)
 }
 
@@ -300,10 +300,12 @@ func verifyCaptionToleratesGuidCasingBetweenBridgeAndDatabase() async throws {
   _ = try store.withConnection { db in
     try db.run("ALTER TABLE message ADD COLUMN guid TEXT")
     try db.run("ALTER TABLE message ADD COLUMN is_sent INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN is_delivered INTEGER")
     try db.run("ALTER TABLE message ADD COLUMN error INTEGER")
     // The row stores the GUID uppercased; the bridge will hand us lowercase.
     try db.run(
-      "UPDATE message SET guid = ?, is_sent = 1, error = 0 WHERE ROWID = 5", "CAPTION-GUID")
+      "UPDATE message SET guid = ?, is_sent = 1, is_delivered = 1, error = 0 WHERE ROWID = 5",
+      "CAPTION-GUID")
     try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 5)")
   }
 
@@ -314,6 +316,29 @@ func verifyCaptionToleratesGuidCasingBetweenBridgeAndDatabase() async throws {
     timeout: 0.5
   )
   #expect(result == .delivered)
+}
+
+@Test
+func verifyCaptionKeepsLocallySentRowUnknownUntilDelivered() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
+  _ = try store.withConnection { db in
+    try db.run("ALTER TABLE message ADD COLUMN guid TEXT")
+    try db.run("ALTER TABLE message ADD COLUMN is_sent INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN is_delivered INTEGER")
+    try db.run("ALTER TABLE message ADD COLUMN error INTEGER")
+    try db.run(
+      "UPDATE message SET guid = ?, is_sent = 1, is_delivered = 0, error = 0 WHERE ROWID = 5",
+      "SENT-GUID")
+    try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 5)")
+  }
+
+  let result = await PollCaptionStatus.verifyCaption(
+    captionGUID: "sent-guid",
+    chatGUID: "iMessage;-;+123",
+    store: store,
+    timeout: 0.2
+  )
+  #expect(result == .unknown)
 }
 
 @Test

--- a/Tests/imsgTests/PollCaptionStatusTests.swift
+++ b/Tests/imsgTests/PollCaptionStatusTests.swift
@@ -175,6 +175,37 @@ func pollSendHumanSummaryStaysQuietWhenCaptionLands() async throws {
   #expect(!output.contains("caption NOT delivered"))
 }
 
+// MARK: - The verifier itself
+
+@Test
+func verifyCaptionDoesNotGuessWithoutAStore() async throws {
+  // No store means the check never ran. That must stay distinct from a
+  // negative verdict, or callers read "we did not look" as "it never arrived".
+  let result = await PollCaptionStatus.verifyCaption(
+    captionGUID: "caption-guid", chatGUID: "iMessage;-;+15551234567", store: nil)
+  #expect(result == nil)
+}
+
+@Test
+func verifyCaptionDoesNotGuessWithoutAGuidToLookFor() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let result = await PollCaptionStatus.verifyCaption(
+    captionGUID: "", chatGUID: "iMessage;-;+15551234567", store: store)
+  #expect(result == nil)
+}
+
+@Test
+func verifyCaptionReportsAnAbsentRowAsUndelivered() async throws {
+  let store = try CommandTestDatabase.makeStoreForRPC()
+  let result = await PollCaptionStatus.verifyCaption(
+    captionGUID: "never-sent-guid",
+    chatGUID: "iMessage;-;+15551234567",
+    store: store,
+    timeout: 0.2
+  )
+  #expect(result == false)
+}
+
 // MARK: - RPC surface
 
 /// Runs `poll.send` over the RPC server, returning the response result object.

--- a/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
+++ b/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
@@ -163,7 +163,9 @@ func rpcPollSendInvokesBridgeWithResolvedChat() async throws {
           "question": "Dinner?",
         ],
       ]
-    }
+    },
+    // Stubbed: this test asserts bridge wiring, not row verification.
+    verifyCaption: { _, _, _ in true }
   )
 
   await server.handleLineForTesting(
@@ -201,7 +203,9 @@ func rpcPollSendUsesCommentOverrideWithoutPollGuid() async throws {
     invokeBridge: { action, params in
       calls.append((action, params))
       return [:]
-    }
+    },
+    // Stubbed: this test asserts bridge wiring, not row verification.
+    verifyCaption: { _, _, _ in true }
   )
 
   await server.handleLineForTesting(

--- a/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
+++ b/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
@@ -165,7 +165,7 @@ func rpcPollSendInvokesBridgeWithResolvedChat() async throws {
       ]
     },
     // Stubbed: this test asserts bridge wiring, not row verification.
-    verifyCaption: { _, _, _ in true }
+    verifyCaption: { _, _, _ in .delivered }
   )
 
   await server.handleLineForTesting(
@@ -205,7 +205,7 @@ func rpcPollSendUsesCommentOverrideWithoutPollGuid() async throws {
       return [:]
     },
     // Stubbed: this test asserts bridge wiring, not row verification.
-    verifyCaption: { _, _, _ in true }
+    verifyCaption: { _, _, _ in .delivered }
   )
 
   await server.handleLineForTesting(

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -87,12 +87,23 @@ Messages does not render the payload title on the poll balloon, so `poll send` f
 The caption *is* the question as far as recipients are concerned, so `poll send` reports whether it landed under `comment` rather than leaving a failure on stderr:
 
 ```json
+{"messageGuid":"...","comment":{"requested":true,"sent":true,"verified":true}}
+{"messageGuid":"...","comment":{"requested":true,"sent":false,"verified":false,"error":"The bridge accepted the caption but no matching row appeared in the target chat.","disposition":"may_have_completed","retry_safe":false}}
+{"messageGuid":"...","comment":{"requested":true,"sent":false,"error":"...","disposition":"...","retry_safe":false}}
 {"messageGuid":"...","comment":{"requested":true,"sent":true}}
-{"messageGuid":"...","comment":{"requested":true,"sent":false,"error":"...","disposition":"may_have_completed","retry_safe":false}}
 {"messageGuid":"...","comment":{"requested":false,"sent":false}}
 ```
 
-`requested` is false when the caption was suppressed. A `requested` caption that is not `sent` means the poll balloon is on screen with no question next to it: re-send just the caption text, never the poll, or the balloon is duplicated. `disposition` and `retry_safe` come from the transport's delivery report when it produced one — decide re-send safety from `disposition`, not by matching `error`. The command still exits 0 in that case, because the poll itself did land.
+`requested` is false when the caption was suppressed. **A `requested` caption that is not `sent` means the poll balloon is on screen with no question next to it**: re-send just the caption text, never the poll, or the balloon is duplicated. The command still exits 0 in that case, because the poll itself did land.
+
+A bridge acknowledgement only proves the transport accepted the send, so `poll send` also looks for the caption's row in the target chat before claiming delivery:
+
+- `sent: true, verified: true` — the row was found. The question is visible.
+- `sent: false, verified: false` — the bridge accepted it but the row never appeared. Treated as undelivered, with the transport's `may_have_completed` disposition because nothing can prove which way it went.
+- `sent: true` with no `verified` key — the check could not run (no readable database, or no caption GUID to look for). Transport acknowledgement only; not a delivery claim.
+- `sent: false` with a `disposition` other than the above — the caption send itself failed.
+
+`disposition` and `retry_safe` come from the transport's delivery report — decide re-send safety from `disposition`, not by matching `error`.
 
 Vote or remove a vote with one option selector:
 

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -99,7 +99,7 @@ The caption *is* the question as far as recipients are concerned, so `poll send`
 A bridge acknowledgement only proves the transport accepted the send, so `poll send` also looks for the caption's row in the target chat before claiming delivery:
 
 - `sent: true, verified: true` — the row was found. The question is visible.
-- `sent: false, verified: false` — the bridge accepted it but the row never appeared. Treated as undelivered, with the transport's `may_have_completed` disposition because nothing can prove which way it went.
+- `sent: false, verified: false` — the bridge accepted it but the row never reached a sent state: it never appeared, Messages recorded the send as failed, or it was still pending at the deadline. Treated as undelivered, with the transport's `may_have_completed` disposition because nothing can prove which way it went.
 - `sent: true` with no `verified` key — the check could not run (no readable database, or no caption GUID to look for). Transport acknowledgement only; not a delivery claim.
 - `sent: false` with a `disposition` other than the above — the caption send itself failed.
 

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -88,22 +88,25 @@ The caption *is* the question as far as recipients are concerned, so `poll send`
 
 ```json
 {"messageGuid":"...","comment":{"requested":true,"sent":true,"verified":true}}
-{"messageGuid":"...","comment":{"requested":true,"sent":false,"verified":false,"error":"The bridge accepted the caption but no matching row appeared in the target chat.","disposition":"may_have_completed","retry_safe":false}}
-{"messageGuid":"...","comment":{"requested":true,"sent":false,"error":"...","disposition":"...","retry_safe":false}}
-{"messageGuid":"...","comment":{"requested":true,"sent":true}}
+{"messageGuid":"...","comment":{"requested":true,"sent":null,"verified":false,"error":"The bridge accepted the caption, but delivery was not confirmed before the verification deadline.","disposition":"may_have_completed","retry_safe":false}}
+{"messageGuid":"...","comment":{"requested":true,"sent":false,"error":"...","disposition":"not_started","retry_safe":true}}
+{"messageGuid":"...","comment":{"requested":true,"sent":null,"error":"...","disposition":"still_in_flight","retry_safe":false}}
+{"messageGuid":"...","comment":{"requested":true,"sent":null}}
 {"messageGuid":"...","comment":{"requested":false,"sent":false}}
 ```
 
-`requested` is false when the caption was suppressed. **A `requested` caption that is not `sent` means the poll balloon is on screen with no question next to it**: re-send just the caption text, never the poll, or the balloon is duplicated. The command still exits 0 in that case, because the poll itself did land.
+`requested` is false when the caption was suppressed. `sent` is tri-state: `true` means confirmed delivery, `false` means confirmed non-delivery, and `null` means delivery is unknown. The command still exits 0 when only the caption fails or remains unknown because the poll itself did land.
 
 A bridge acknowledgement only proves the transport accepted the send, so `poll send` also looks for the caption's row in the target chat before claiming delivery:
 
-- `sent: true, verified: true` — the row was found. The question is visible.
-- `sent: false, verified: false` — the bridge accepted it but the row never reached a sent state: it never appeared, Messages recorded the send as failed, or it was still pending at the deadline. Treated as undelivered, with the transport's `may_have_completed` disposition because nothing can prove which way it went.
-- `sent: true` with no `verified` key — the check could not run (no readable database, or no caption GUID to look for). Transport acknowledgement only; not a delivery claim.
-- `sent: false` with a `disposition` other than the above — the caption send itself failed.
+- `sent: true, verified: true`: the row reached a sent or delivered state. The question is visible.
+- `sent: false, verified: false`: Messages recorded the caption row as failed. This is confirmed non-delivery, but retry safety is not inferred from the database.
+- `sent: null, verified: false`: the row was absent or still pending at the verification deadline. Delivery is unknown because the caption may still arrive later.
+- `sent: null` with no `verified` key: the check could not run because there was no readable database or caption GUID. Transport acknowledgement alone is not a delivery claim.
+- `sent: false, retry_safe: true`: the transport proved the caption operation did not start. Re-send only the caption text, never the poll.
+- `sent: null, retry_safe: false`: the transport reported an uncertain or still-running operation. Do not retry automatically.
 
-`disposition` and `retry_safe` come from the transport's delivery report — decide re-send safety from `disposition`, not by matching `error`.
+Only `retry_safe: true` authorizes a caption retry. Never infer retry safety from `sent`, `verified`, or human-readable `error` text.
 
 Vote or remove a vote with one option selector:
 

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -99,9 +99,9 @@ The caption *is* the question as far as recipients are concerned, so `poll send`
 
 A bridge acknowledgement only proves the transport accepted the send, so `poll send` also looks for the caption's row in the target chat before claiming delivery:
 
-- `sent: true, verified: true`: the row reached a sent or delivered state. The question is visible.
+- `sent: true, verified: true`: Messages recorded the row as delivered. The question reached the recipient.
 - `sent: false, verified: false`: Messages recorded the caption row as failed. This is confirmed non-delivery, but retry safety is not inferred from the database.
-- `sent: null, verified: false`: the row was absent or still pending at the verification deadline. Delivery is unknown because the caption may still arrive later.
+- `sent: null, verified: false`: the row was absent, pending, or only locally sent at the verification deadline. Delivery is unknown because the caption may still arrive or fail later.
 - `sent: null` with no `verified` key: the check could not run because there was no readable database or caption GUID. Transport acknowledgement alone is not a delivery claim.
 - `sent: false, retry_safe: true`: the transport proved the caption operation did not start. Re-send only the caption text, never the poll.
 - `sent: null, retry_safe: false`: the transport reported an uncertain or still-running operation. Do not retry automatically.

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -106,6 +106,10 @@ A bridge acknowledgement only proves the transport accepted the send, so `poll s
 - `sent: false, retry_safe: true`: the transport proved the caption operation did not start. Re-send only the caption text, never the poll.
 - `sent: null, retry_safe: false`: the transport reported an uncertain or still-running operation. Do not retry automatically.
 
+When the bridge returns a caption GUID, `comment.message_guid` identifies that separate message. Use RPC `message.send_status` with this GUID to check an unresolved caption later; do not use the poll GUID or assume the caption is a threaded reply.
+
+CLI output waits for the caption send attempt (the existing bridge send timeout is 150 seconds), then polls delivery for up to eight seconds. These are separate waits, not an end-to-end deadline. A slow or offline recipient can leave delivery unknown at the deadline.
+
 Only `retry_safe: true` authorizes a caption retry. Never infer retry safety from `sent`, `verified`, or human-readable `error` text.
 
 Vote or remove a vote with one option selector:

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -84,6 +84,16 @@ imsg poll send --chat 'iMessage;-;+15551234567' \
 
 Messages does not render the payload title on the poll balloon, so `poll send` follows it with a best-effort caption. Use `--comment` to choose different visible text or `--no-comment` when the caller already sent the context.
 
+The caption *is* the question as far as recipients are concerned, so `poll send` reports whether it landed under `comment` rather than leaving a failure on stderr:
+
+```json
+{"messageGuid":"...","comment":{"requested":true,"sent":true}}
+{"messageGuid":"...","comment":{"requested":true,"sent":false,"error":"...","disposition":"may_have_completed","retry_safe":false}}
+{"messageGuid":"...","comment":{"requested":false,"sent":false}}
+```
+
+`requested` is false when the caption was suppressed. A `requested` caption that is not `sent` means the poll balloon is on screen with no question next to it: re-send just the caption text, never the poll, or the balloon is duplicated. `disposition` and `retry_safe` come from the transport's delivery report when it produced one — decide re-send safety from `disposition`, not by matching `error`. The command still exits 0 in that case, because the poll itself did land.
+
 Vote or remove a vote with one option selector:
 
 ```bash

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -716,12 +716,12 @@ Because the balloon shows no question without it, the caption's outcome is repor
 | --- | --- |
 | `requested` | Whether a caption was supposed to be sent (`false` for `suppress_comment: true`). |
 | `sent` | Whether it landed. Not reported true on a bare bridge acknowledgement when the row can be checked. |
-| `verified` | Whether the caption's row was found in the target chat. Absent when the check could not run — that is "we did not look", not a verdict. |
+| `verified` | Whether the caption's row reached a sent or delivered state in the target chat. A row that Messages recorded as failed, or one still pending at the deadline, is not verified — a row existing is not delivery. Absent when the check could not run at all, which is "we did not look", not a verdict. |
 | `error` | Redacted failure text. Present only when `requested` and not `sent`. |
 | `disposition` | `not_started`, `may_have_completed`, or `still_in_flight`, when the transport reported a delivery failure. |
 | `retry_safe` | Whether re-sending the caption is safe. Decide from this or `disposition`, never by matching `error`. |
 
-`requested: true` with `sent: false` means the poll is on screen with no visible question. Re-send the caption text alone; re-sending `poll.send` would duplicate the balloon. This includes the case where the bridge acknowledged the caption but its row never appeared (`verified: false`, `disposition: may_have_completed`) — an accepted caption that did not persist leaves the recipient with exactly the same unlabelled balloon as one that was never sent.
+`requested: true` with `sent: false` means the poll is on screen with no visible question. Re-send the caption text alone; re-sending `poll.send` would duplicate the balloon. This includes the case where the bridge acknowledged the caption but its row never reached a sent state — never appeared, recorded as failed, or still pending at the deadline (`verified: false`, `disposition: may_have_completed`) — an accepted caption that did not persist leaves the recipient with exactly the same unlabelled balloon as one that was never sent.
 
 ### Stickers
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -716,7 +716,7 @@ Because the balloon shows no question without it, the caption's outcome is repor
 | --- | --- |
 | `requested` | Whether a caption was supposed to be sent (`false` for `suppress_comment: true`). |
 | `sent` | Tri-state delivery result: `true` means delivered, `false` means confirmed not delivered, and `null` means delivery is unknown. A bare bridge acknowledgement is never reported as `true`. |
-| `verified` | Whether the caption's row reached a sent or delivered state in the target chat. `false` can mean a recorded failure or an absent/pending row at the deadline; use `sent` to distinguish confirmed failure from unknown delivery. Absent when the check could not run at all. |
+| `verified` | Whether Messages recorded the caption as delivered in the target chat. `false` can mean a recorded failure or a row that was absent, pending, or only locally sent at the deadline; use `sent` to distinguish confirmed failure from unknown delivery. Absent when the check could not run at all. |
 | `error` | Failure or unresolved-delivery diagnostic. Typed transport failures are redacted. |
 | `disposition` | `not_started`, `may_have_completed`, or `still_in_flight`. Transport failures supply this directly; verification timeout conservatively synthesizes `may_have_completed`. |
 | `retry_safe` | Whether re-sending the caption is safe. Transport failures supply this directly; verification timeout synthesizes `false`. Never infer it by matching `error`. |

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -714,12 +714,15 @@ Because the balloon shows no question without it, the caption's outcome is repor
 
 | Field | Meaning |
 | --- | --- |
+| `message_guid` | Caption message GUID when returned by the bridge; use it with `message.send_status` to check again later. Omitted when unavailable. |
 | `requested` | Whether a caption was supposed to be sent (`false` for `suppress_comment: true`). |
 | `sent` | Tri-state delivery result: `true` means delivered, `false` means confirmed not delivered, and `null` means delivery is unknown. A bare bridge acknowledgement is never reported as `true`. |
 | `verified` | Whether Messages recorded the caption as delivered in the target chat. `false` can mean a recorded failure or a row that was absent, pending, or only locally sent at the deadline; use `sent` to distinguish confirmed failure from unknown delivery. Absent when the check could not run at all. |
 | `error` | Failure or unresolved-delivery diagnostic. Typed transport failures are redacted. |
 | `disposition` | `not_started`, `may_have_completed`, or `still_in_flight`. Transport failures supply this directly; verification timeout conservatively synthesizes `may_have_completed`. |
 | `retry_safe` | Whether re-sending the caption is safe. Transport failures supply this directly; verification timeout synthesizes `false`. Never infer it by matching `error`. |
+
+After the caption bridge call completes, RPC polls its delivery for up to two seconds while holding the serialized mutation lane. Database work is additional to that polling bound. Unknown delivery retains the caption GUID when available so a later `message.send_status` query can resolve it without another send. Captions are plain messages, not threaded replies to the poll.
 
 Retry the caption text only when `retry_safe` is `true`, which means the transport proved the operation did not start. `sent: null` is delivery-unknown: the caption may still arrive, so do not retry automatically. Never re-run `poll.send` to recover a caption because that would duplicate the poll balloon.
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -715,13 +715,13 @@ Because the balloon shows no question without it, the caption's outcome is repor
 | Field | Meaning |
 | --- | --- |
 | `requested` | Whether a caption was supposed to be sent (`false` for `suppress_comment: true`). |
-| `sent` | Whether it landed. Not reported true on a bare bridge acknowledgement when the row can be checked. |
-| `verified` | Whether the caption's row reached a sent or delivered state in the target chat. A row that Messages recorded as failed, or one still pending at the deadline, is not verified — a row existing is not delivery. Absent when the check could not run at all, which is "we did not look", not a verdict. |
-| `error` | Redacted failure text. Present only when `requested` and not `sent`. |
-| `disposition` | `not_started`, `may_have_completed`, or `still_in_flight`, when the transport reported a delivery failure. |
-| `retry_safe` | Whether re-sending the caption is safe. Decide from this or `disposition`, never by matching `error`. |
+| `sent` | Tri-state delivery result: `true` means delivered, `false` means confirmed not delivered, and `null` means delivery is unknown. A bare bridge acknowledgement is never reported as `true`. |
+| `verified` | Whether the caption's row reached a sent or delivered state in the target chat. `false` can mean a recorded failure or an absent/pending row at the deadline; use `sent` to distinguish confirmed failure from unknown delivery. Absent when the check could not run at all. |
+| `error` | Failure or unresolved-delivery diagnostic. Typed transport failures are redacted. |
+| `disposition` | `not_started`, `may_have_completed`, or `still_in_flight`. Transport failures supply this directly; verification timeout conservatively synthesizes `may_have_completed`. |
+| `retry_safe` | Whether re-sending the caption is safe. Transport failures supply this directly; verification timeout synthesizes `false`. Never infer it by matching `error`. |
 
-`requested: true` with `sent: false` means the poll is on screen with no visible question. Re-send the caption text alone; re-sending `poll.send` would duplicate the balloon. This includes the case where the bridge acknowledged the caption but its row never reached a sent state — never appeared, recorded as failed, or still pending at the deadline (`verified: false`, `disposition: may_have_completed`) — an accepted caption that did not persist leaves the recipient with exactly the same unlabelled balloon as one that was never sent.
+Retry the caption text only when `retry_safe` is `true`, which means the transport proved the operation did not start. `sent: null` is delivery-unknown: the caption may still arrive, so do not retry automatically. Never re-run `poll.send` to recover a caption because that would duplicate the poll balloon.
 
 ### Stickers
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -677,16 +677,22 @@ With a caption override:
 {"jsonrpc":"2.0","id":"poll","method":"poll.send","params":{"chat_id":42,"question":"Dinner?","comment":"Vote by 5pm","options":["Pizza","Sushi"]}}
 ```
 
+Response to either of the two requests above, which do send a caption:
+
+```json
+{"ok":true,"event":"imessage.poll.created","guid":"...","message_id":"...","comment":{"requested":true,"sent":true,"verified":true},"poll":{"kind":"created","event":"imessage.poll.created","question":"Dinner?","options":[{"id":"...","text":"Pizza"},{"id":"...","text":"Sushi"}]}}
+```
+
 Without a caption:
 
 ```json
 {"jsonrpc":"2.0","id":"poll","method":"poll.send","params":{"chat_id":42,"question":"Dinner?","suppress_comment":true,"options":["Pizza","Sushi"]}}
 ```
 
-Response:
+That request suppresses the caption, so its response reports it as never requested:
 
 ```json
-{"ok":true,"event":"imessage.poll.created","guid":"...","message_id":"...","comment":{"requested":true,"sent":true},"poll":{"kind":"created","event":"imessage.poll.created","question":"Dinner?","options":[{"id":"...","text":"Pizza"},{"id":"...","text":"Sushi"}]}}
+{"ok":true,"event":"imessage.poll.created","guid":"...","message_id":"...","comment":{"requested":false,"sent":false},"poll":{"kind":"created","event":"imessage.poll.created","question":"Dinner?","options":[{"id":"...","text":"Pizza"},{"id":"...","text":"Sushi"}]}}
 ```
 
 `poll.vote` casts a native vote after validating the poll and option against local history.
@@ -709,12 +715,13 @@ Because the balloon shows no question without it, the caption's outcome is repor
 | Field | Meaning |
 | --- | --- |
 | `requested` | Whether a caption was supposed to be sent (`false` for `suppress_comment: true`). |
-| `sent` | Whether it landed. |
+| `sent` | Whether it landed. Not reported true on a bare bridge acknowledgement when the row can be checked. |
+| `verified` | Whether the caption's row was found in the target chat. Absent when the check could not run — that is "we did not look", not a verdict. |
 | `error` | Redacted failure text. Present only when `requested` and not `sent`. |
 | `disposition` | `not_started`, `may_have_completed`, or `still_in_flight`, when the transport reported a delivery failure. |
 | `retry_safe` | Whether re-sending the caption is safe. Decide from this or `disposition`, never by matching `error`. |
 
-`requested: true` with `sent: false` means the poll is on screen with no visible question. Re-send the caption text alone; re-sending `poll.send` would duplicate the balloon.
+`requested: true` with `sent: false` means the poll is on screen with no visible question. Re-send the caption text alone; re-sending `poll.send` would duplicate the balloon. This includes the case where the bridge acknowledged the caption but its row never appeared (`verified: false`, `disposition: may_have_completed`) — an accepted caption that did not persist leaves the recipient with exactly the same unlabelled balloon as one that was never sent.
 
 ### Stickers
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -686,7 +686,7 @@ Without a caption:
 Response:
 
 ```json
-{"ok":true,"event":"imessage.poll.created","guid":"...","message_id":"...","poll":{"kind":"created","event":"imessage.poll.created","question":"Dinner?","options":[{"id":"...","text":"Pizza"},{"id":"...","text":"Sushi"}]}}
+{"ok":true,"event":"imessage.poll.created","guid":"...","message_id":"...","comment":{"requested":true,"sent":true},"poll":{"kind":"created","event":"imessage.poll.created","question":"Dinner?","options":[{"id":"...","text":"Pizza"},{"id":"...","text":"Sushi"}]}}
 ```
 
 `poll.vote` casts a native vote after validating the poll and option against local history.
@@ -702,7 +702,19 @@ it must reconstruct the caller's currently selected options.
 {"jsonrpc":"2.0","id":"unvote","method":"polls.unvote","params":{"chat_id":42,"poll_guid":"POLL-GUID","option":"Sushi"}}
 ```
 
-`messages.poll.send` is accepted as an alias for `poll.send`. The caption echo is deliberately best-effort: if the poll is created but the follow-up caption send fails, the RPC still returns the poll result to avoid retrying and creating a duplicate poll.
+`messages.poll.send` is accepted as an alias for `poll.send`. The caption echo is deliberately best-effort: if the poll is created but the follow-up caption send fails, the RPC still returns the poll result with `ok: true` to avoid retrying and creating a duplicate poll.
+
+Because the balloon shows no question without it, the caption's outcome is reported in the result under `comment`:
+
+| Field | Meaning |
+| --- | --- |
+| `requested` | Whether a caption was supposed to be sent (`false` for `suppress_comment: true`). |
+| `sent` | Whether it landed. |
+| `error` | Redacted failure text. Present only when `requested` and not `sent`. |
+| `disposition` | `not_started`, `may_have_completed`, or `still_in_flight`, when the transport reported a delivery failure. |
+| `retry_safe` | Whether re-sending the caption is safe. Decide from this or `disposition`, never by matching `error`. |
+
+`requested: true` with `sent: false` means the poll is on screen with no visible question. Re-send the caption text alone; re-sending `poll.send` would duplicate the balloon.
 
 ### Stickers
 


### PR DESCRIPTION
A poll balloon can succeed while its separate question caption fails or remains undelivered. CLI previously printed success before the caption attempt, and RPC only logged caption errors to stderr, so machine callers could mistake a question-less poll for complete delivery.

Both surfaces now return a separate `comment` outcome. Only a Messages database row recorded as delivered in the target chat produces `sent: true`; pending, locally sent, absent, and unavailable checks remain unknown. Typed transport dispositions preserve safe retry guidance, and RPC retains its existing handling of a still-running mutation. Overall poll success remains intact so a caption problem never encourages duplicate poll creation.

The maintainer pass also preserves the caption's `message_guid` for later `message.send_status` queries, uses a monotonic polling deadline, removes redundant predicate-only tests, and documents that captions are plain messages rather than threaded replies.

Latency decision: retain one final CLI result after the caption attempt. The existing caption bridge wait can reach 150 seconds; delivery polling then adds up to eight seconds in CLI or two seconds in the serialized RPC mutation lane. Database work is outside those polling bounds. Unknown results must not trigger an automatic retry.

Validation:
- New CLI/RPC output assertions failed before the caption GUID was retained, then passed.
- Real SQLite fixtures cover delivered, failed, locally sent, pending, absent, mixed-case GUID, and wrong-chat rows; CLI/RPC tests cover output and retry semantics.
- `make test`: 715 Swift tests pass plus docs-site tests on the branch.
- `make lint`: passes with the existing 16 non-serious warnings.
- Codex autoreview: no actionable P0–P2 findings.
- Universal build and exact-head CI are recorded in the maintainer follow-up.

Native proof limitation: @omarshahine reported delivered-only native proof on head `9f7c756` in the comments. The maintainer did not send another real poll because no test recipient was designated. The earlier proof's `reply_to_guid` description is not relied on: the implementation intentionally clears thread metadata for plain captions. Fresh verification should use the returned `comment.message_guid` and target-chat membership, followed by `message.send_status`. No claim of a new native send is made here.

Thanks to @omarshahine for the original repair and native investigation. Release-note context is kept here rather than in an Unreleased changelog edit.
