### PR TITLE
fix(ci): restrict workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   macos:
     runs-on: macos-26


### PR DESCRIPTION
## Summary

- give the CI workflow only read access to repository contents
- resolve CodeQL workflow-permission alerts 1 and 2

## CodeQL

- https://github.com/openclaw/imsg/security/code-scanning/1
- https://github.com/openclaw/imsg/security/code-scanning/2

## Verification

- `actionlint .github/workflows/ci.yml`
- Ruby YAML parse
- `git diff --check`
