### PR TITLE
fix(docs): harden generated table of contents

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,8 @@ on:
       - "docs/**"
       - "scripts/build-docs-site.mjs"
       - "scripts/docs-site-assets.mjs"
+      - "scripts/html-text.mjs"
+      - "scripts/html-text.test.mjs"
       - "Makefile"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
@@ -37,6 +39,9 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
+
+      - name: Test docs helpers
+        run: node --test scripts/html-text.test.mjs
 
       - name: Build docs site
         run: make docs-site

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Let headless `watch` and `search` start without waiting for an undetermined Contacts permission prompt while preserving interactive prompting (#238, thanks @SebTardif).
+- Strip generated documentation heading markup in one pass so malformed tag boundaries cannot survive into the table of contents.
 
 ## 0.14.1 - 2026-08-11
 

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { brandMarkSvg, css, faviconSvg, js, preThemeScript, themeToggleHtml } from "./docs-site-assets.mjs";
+import { stripHtmlTags } from "./html-text.mjs";
 
 const root = process.cwd();
 const docsDir = path.join(root, "docs");
@@ -466,10 +467,7 @@ function tocFromHtml(html) {
   const re = /<h([23]) id="([^"]+)">([\s\S]*?)<\/h[23]>/g;
   let m;
   while ((m = re.exec(html))) {
-    const text = m[3]
-      .replace(/<a class="anchor"[^>]*>.*?<\/a>/, "")
-      .replace(/<[^>]+>/g, "")
-      .trim();
+    const text = stripHtmlTags(m[3]).replace(/^#/, "").trim();
     items.push({ level: Number(m[1]), id: m[2], text });
   }
   if (items.length < 2) return "";

--- a/scripts/html-text.mjs
+++ b/scripts/html-text.mjs
@@ -1,0 +1,31 @@
+function startsHtmlTag(value, index) {
+  const next = value[index + 1]?.toLowerCase();
+  return next === "/" || next === "!" || next === "?" || (next >= "a" && next <= "z");
+}
+
+export function stripHtmlTags(value) {
+  const text = [];
+  let insideTag = false;
+  let quote = "";
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (!insideTag) {
+      if (character === "<" && startsHtmlTag(value, index)) {
+        while (text.at(-1) === "<") text.pop();
+        insideTag = true;
+      } else {
+        text.push(character);
+      }
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = "";
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === ">") {
+      insideTag = false;
+    }
+  }
+  return text.join("");
+}

--- a/scripts/html-text.test.mjs
+++ b/scripts/html-text.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { stripHtmlTags } from "./html-text.mjs";
+
+test("stripHtmlTags removes nested and unterminated markup in one pass", () => {
+  assert.equal(
+    stripHtmlTags('<a class="anchor" href="#heading">#</a><em>Heading</em>'),
+    "#Heading",
+  );
+  assert.equal(stripHtmlTags("<strong>broken"), "broken");
+  assert.equal(stripHtmlTags("Heading <strong"), "Heading ");
+  assert.equal(stripHtmlTags('<span title="1 > 0">Heading</span>'), "Heading");
+  assert.equal(stripHtmlTags("1 < 2"), "1 < 2");
+  assert.equal(stripHtmlTags("<<<script>img>"), "img>");
+});


### PR DESCRIPTION
## Summary

- replace sequential heading-tag regexes with the reviewed one-pass HTML tag stripper
- cover nested, quoted, unterminated, comparison, and reconstructed-tag inputs
- run the focused helper test in the Pages workflow
- document the fix in the changelog

## CodeQL

- https://github.com/openclaw/imsg/security/code-scanning/3

## Verification

- `node --test scripts/html-text.test.mjs`
- `make docs-site`
- `node --check scripts/build-docs-site.mjs`
- `node --check scripts/html-text.mjs`
- `node --check scripts/html-text.test.mjs`
- `actionlint .github/workflows/pages.yml`
- Ruby YAML parse
- `git diff --check`
