### PR TITLE
fix(ci): restrict workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   macos:
     runs-on: macos-26


### PR DESCRIPTION
## Summary

- restrict the CI workflow token to `contents: read`
- preserve both macOS and Linux Swift validation jobs unchanged
- remediate CodeQL alerts 1 and 2 without touching docs sanitizer or generated dependency alerts

## Permission matrix

| Job | Consumer | Required permission |
| --- | --- | --- |
| `macos` | `actions/checkout@v7` | `contents: read` |
| `macos` | SwiftLint, lint, tests, build | none |
| `linux-read-core` | `actions/checkout@v7` | `contents: read` |
| `linux-read-core` | apt, SwiftPM, tests, build | none |

No step calls the GitHub API, uploads artifacts, writes checks, publishes packages, or mutates repository content.

## Verification

- `actionlint -config-file .github/actionlint.yaml .github/workflows/ci.yml`
- YAML parse
- `make clean`
- `make lint`
- `make test` (671 tests)
- `make build ARCHES="$(uname -m)"`
- direct AWS Crabbox, Swift 6.3.3 Linux container: 5 tests and CLI build
  - https://crabbox.openclaw.ai/portal/runs/run_cea5dfada7be
- high-reasoning autoreview: clean, 0.99 confidence
- test audit: no test change; exact-head CI and CodeQL are the owner-boundary proof

## Scope

Reference only: #240. This replacement branch was rebuilt from current `main`; #240 was not modified.

CodeQL:

- https://github.com/openclaw/imsg/security/code-scanning/1
- https://github.com/openclaw/imsg/security/code-scanning/2

No changelog, release, signing, schedule, sanitizer, or generated SQLite.swift changes.
