### PR TITLE
fix(docs): derive TOC from renderer headings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help:
 	@printf "%s\n" \
 		"make format     - swift format in-place" \
 		"make lint       - swift format lint + swiftlint" \
-		"make test       - sync version, patch deps, run swift test" \
+		"make test       - run docs-site and Swift tests" \
 		"make build      - universal release build into bin/" \
 		"make build-dylib - build injectable dylib for Messages.app" \
 		"make imsg       - clean rebuild + run debug binary (ARGS=...)" \
@@ -21,6 +21,7 @@ lint:
 	swiftlint
 
 test:
+	node --test scripts/build-docs-site.test.mjs
 	scripts/generate-version.sh
 	swift package resolve
 	scripts/patch-deps.sh

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -61,15 +61,15 @@ for (const section of nav) for (const page of section.pages) sectionByRel.set(pa
 const orderedPages = nav.flatMap((s) => s.pages);
 
 for (const page of pages) {
-  const html = markdownToHtml(page.markdown, page.rel);
-  const toc = tocFromHtml(html);
+  const rendered = renderMarkdown(page.markdown, page.rel);
+  const toc = renderToc(rendered.headings);
   const idx = orderedPages.findIndex((p) => p.rel === page.rel);
   const prev = idx > 0 ? orderedPages[idx - 1] : null;
   const next = idx >= 0 && idx < orderedPages.length - 1 ? orderedPages[idx + 1] : null;
   const sectionName = sectionByRel.get(page.rel) || "Reference";
   const pageOut = path.join(outDir, page.outRel);
   fs.mkdirSync(path.dirname(pageOut), { recursive: true });
-  fs.writeFileSync(pageOut, layout({ page, html, toc, prev, next, sectionName }), "utf8");
+  fs.writeFileSync(pageOut, layout({ page, html: rendered.html, toc, prev, next, sectionName }), "utf8");
 }
 
 fs.writeFileSync(path.join(outDir, "favicon.svg"), faviconSvg(), "utf8");
@@ -211,7 +211,15 @@ function titleize(input) {
   return input.replaceAll("-", " ").replace(/\b\w/g, (m) => m.toUpperCase());
 }
 
-function markdownToHtml(markdown, currentRel) {
+function renderMarkdown(markdown, currentRel) {
+  const context = { headings: [], headingIds: new Set() };
+  return {
+    html: markdownToHtml(markdown, currentRel, context),
+    headings: context.headings,
+  };
+}
+
+function markdownToHtml(markdown, currentRel, context) {
   const lines = markdown.replace(/\r\n/g, "\n").split("\n");
   const html = [];
   let paragraph = [];
@@ -221,7 +229,7 @@ function markdownToHtml(markdown, currentRel) {
 
   const flushParagraph = () => {
     if (!paragraph.length) return;
-    html.push(`<p>${inline(paragraph.join(" "), currentRel)}</p>`);
+    html.push(`<p>${inline(paragraph.join(" "), currentRel).html}</p>`);
     paragraph = [];
   };
   const closeList = () => {
@@ -231,7 +239,7 @@ function markdownToHtml(markdown, currentRel) {
   };
   const flushBlockquote = () => {
     if (!blockquote.length) return;
-    const inner = markdownToHtml(blockquote.join("\n"), currentRel);
+    const inner = markdownToHtml(blockquote.join("\n"), currentRel, context);
     html.push(`<blockquote>${inner}</blockquote>`);
     blockquote = [];
   };
@@ -303,12 +311,15 @@ function markdownToHtml(markdown, currentRel) {
       closeList();
       const level = heading[1].length;
       const text = heading[2].trim();
-      const id = slug(text);
       const inner = inline(text, currentRel);
+      const id = uniqueHeadingId(text, context.headingIds);
+      if (level === 2 || level === 3) {
+        context.headings.push({ level, id, label: inner.text });
+      }
       if (level === 1) {
-        html.push(`<h1 id="${id}">${inner}</h1>`);
+        html.push(`<h1 id="${id}">${inner.html}</h1>`);
       } else {
-        html.push(`<h${level} id="${id}"><a class="anchor" href="#${id}" aria-label="Anchor link">#</a>${inner}</h${level}>`);
+        html.push(`<h${level} id="${id}"><a class="anchor" href="#${id}" aria-label="Anchor link">#</a>${inner.html}</h${level}>`);
       }
       continue;
     }
@@ -327,8 +338,8 @@ function markdownToHtml(markdown, currentRel) {
         i += 1;
         rows.push(splitRow(lines[i]));
       }
-      const th = header.map((c, idx) => `<th${aligns[idx] ? ` style="text-align:${aligns[idx]}"` : ""}>${inline(c, currentRel)}</th>`).join("");
-      const tb = rows.map((r) => `<tr>${r.map((c, idx) => `<td${aligns[idx] ? ` style="text-align:${aligns[idx]}"` : ""}>${inline(c, currentRel)}</td>`).join("")}</tr>`).join("");
+      const th = header.map((c, idx) => `<th${aligns[idx] ? ` style="text-align:${aligns[idx]}"` : ""}>${inline(c, currentRel).html}</th>`).join("");
+      const tb = rows.map((r) => `<tr>${r.map((c, idx) => `<td${aligns[idx] ? ` style="text-align:${aligns[idx]}"` : ""}>${inline(c, currentRel).html}</td>`).join("")}</tr>`).join("");
       html.push(`<table><thead><tr>${th}</tr></thead><tbody>${tb}</tbody></table>`);
       continue;
     }
@@ -342,7 +353,7 @@ function markdownToHtml(markdown, currentRel) {
         list = tag;
         html.push(`<${tag}>`);
       }
-      html.push(`<li>${inline((bullet || numbered)[1], currentRel)}</li>`);
+      html.push(`<li>${inline((bullet || numbered)[1], currentRel).html}</li>`);
       continue;
     }
     paragraph.push(line.trim());
@@ -424,19 +435,27 @@ function span(kind, value) {
 
 function inline(text, currentRel) {
   const stash = [];
-  let out = text.replace(/`([^`]+)`/g, (_, code) => {
-    stash.push(`<code>${escapeHtml(code)}</code>`);
+  const source = text.replace(/`([^`]+)`/g, (_, code) => {
+    stash.push({ html: `<code>${escapeHtml(code)}</code>`, text: code });
     return `\u0000${stash.length - 1}\u0000`;
   });
-  out = escapeHtml(out)
+  let html = escapeHtml(source)
     .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
     .replace(/(^|[^*])\*([^*\s][^*]*?)\*(?!\*)/g, "$1<em>$2</em>")
     .replace(/(^|[^_])_([^_\s][^_]*?)_(?!_)/g, "$1<em>$2</em>")
     .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, label, href) => `<a href="${escapeAttr(rewriteHref(href, currentRel))}">${label}</a>`)
     .replace(/&lt;(https?:\/\/[^\s<>]+)&gt;/g, '<a href="$1">$1</a>');
-  out = out.replace(/\\\|/g, "|");
-  out = out.replace(/&lt;br&gt;/g, "<br>");
-  return out.replace(/\u0000(\d+)\u0000/g, (_, i) => stash[Number(i)]);
+  html = html.replace(/\\\|/g, "|").replace(/&lt;br&gt;/g, "<br>");
+  const label = source
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/(^|[^*])\*([^*\s][^*]*?)\*(?!\*)/g, "$1$2")
+    .replace(/(^|[^_])_([^_\s][^_]*?)_(?!_)/g, "$1$2")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/<(https?:\/\/[^\s<>]+)>/g, "$1")
+    .replace(/\\\|/g, "|")
+    .replace(/<br>/g, "");
+  const restore = (value, key) => value.replace(/\u0000(\d+)\u0000/g, (_, i) => stash[Number(i)][key]);
+  return { html: restore(html, "html"), text: restore(label, "text") };
 }
 
 function rewriteHref(href, currentRel) {
@@ -461,20 +480,10 @@ function rewriteHref(href, currentRel) {
   return `${rewritten}${hash ? `#${hash}` : ""}`;
 }
 
-function tocFromHtml(html) {
-  const items = [];
-  const re = /<h([23]) id="([^"]+)">([\s\S]*?)<\/h[23]>/g;
-  let m;
-  while ((m = re.exec(html))) {
-    const text = m[3]
-      .replace(/<a class="anchor"[^>]*>.*?<\/a>/, "")
-      .replace(/<[^>]+>/g, "")
-      .trim();
-    items.push({ level: Number(m[1]), id: m[2], text });
-  }
+function renderToc(items) {
   if (items.length < 2) return "";
   return `<nav class="toc" aria-label="On this page"><h2>On this page</h2>${items
-    .map((i) => `<a class="toc-l${i.level}" href="#${i.id}">${escapeHtml(i.text)}</a>`)
+    .map((i) => `<a class="toc-l${i.level}" href="#${i.id}">${escapeHtml(i.label)}</a>`)
     .join("")}</nav>`;
 }
 
@@ -641,6 +650,18 @@ function hrefToOutRel(targetOutRel, currentOutRel) {
 
 function slug(text) {
   return text.toLowerCase().replace(/`/g, "").replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+function uniqueHeadingId(text, usedIds) {
+  const base = slug(text) || "section";
+  let id = base;
+  let suffix = 2;
+  while (usedIds.has(id)) {
+    id = `${base}-${suffix}`;
+    suffix += 1;
+  }
+  usedIds.add(id);
+  return id;
 }
 
 function escapeHtml(value) {

--- a/scripts/build-docs-site.test.mjs
+++ b/scripts/build-docs-site.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const builder = path.join(repoRoot, "scripts", "build-docs-site.mjs");
+
+function buildPage(t, body) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "imsg-docs-test-"));
+  const docs = path.join(root, "docs");
+  fs.mkdirSync(docs);
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const writeDoc = (name, content) => fs.writeFileSync(path.join(docs, name), content);
+  writeDoc("index.md", "# Home\n\nWelcome.\n");
+  writeDoc("install.md", "# Install\n\nInstall locally.\n");
+  writeDoc("quickstart.md", "# Quickstart\n\nStart locally.\n");
+  writeDoc("cli.md", body);
+
+  execFileSync(process.execPath, [builder], { cwd: root });
+  const first = fs.readFileSync(path.join(root, "dist", "docs-site", "cli.html"), "utf8");
+  execFileSync(process.execPath, [builder], { cwd: root });
+  const second = fs.readFileSync(path.join(root, "dist", "docs-site", "cli.html"), "utf8");
+
+  assert.equal(second, first);
+  return first;
+}
+
+function pageToc(page) {
+  return page.match(/<nav class="toc"[\s\S]*?<\/nav>/)?.[0];
+}
+
+test("escapes malicious heading text once in the TOC", (t) => {
+  const page = buildPage(
+    t,
+    [
+      "# CLI",
+      "",
+      "## Safe",
+      "",
+      '## <img src=x onerror=alert("toc")> <scr<script>ipt>alert("toc")</scr<script>ipt>',
+      "",
+    ].join("\n"),
+  );
+  const toc = pageToc(page);
+
+  assert.equal(
+    toc,
+    '<nav class="toc" aria-label="On this page"><h2>On this page</h2>' +
+      '<a class="toc-l2" href="#safe">Safe</a>' +
+      '<a class="toc-l2" href="#img-src-x-onerror-alert-toc-scr-script-ipt-alert-toc-scr-script-ipt">' +
+      '&lt;img src=x onerror=alert(&quot;toc&quot;)&gt; ' +
+      '&lt;scr&lt;script&gt;ipt&gt;alert(&quot;toc&quot;)&lt;/scr&lt;script&gt;ipt&gt;</a></nav>',
+  );
+  assert.doesNotMatch(toc, /&amp;lt;|<img|<script/i);
+});
+
+test("renders deterministic TOC entries with unique heading anchors", (t) => {
+  const page = buildPage(
+    t,
+    [
+      "# CLI",
+      "",
+      "## Repeat",
+      "",
+      "> ### **Nested [label](https://example.com)** and `code`",
+      "",
+      "## Repeat",
+      "",
+      "## Repeat 2",
+      "",
+      "### Fish &amp; Chips",
+      "",
+    ].join("\n"),
+  );
+  const toc = pageToc(page);
+
+  assert.equal(
+    toc,
+    '<nav class="toc" aria-label="On this page"><h2>On this page</h2>' +
+      '<a class="toc-l2" href="#repeat">Repeat</a>' +
+      '<a class="toc-l3" href="#nested-label-https-example-com-and-code">Nested label and code</a>' +
+      '<a class="toc-l2" href="#repeat-2">Repeat</a>' +
+      '<a class="toc-l2" href="#repeat-2-2">Repeat 2</a>' +
+      '<a class="toc-l3" href="#fish-amp-chips">Fish &amp;amp; Chips</a></nav>',
+  );
+
+  const headingIds = [...page.matchAll(/<h[23] id="([^"]+)"/g)].map((match) => match[1]);
+  const tocIds = [...toc.matchAll(/href="#([^"]+)"/g)].map((match) => match[1]);
+  assert.deepEqual(headingIds, tocIds);
+  assert.equal(new Set(headingIds).size, headingIds.length);
+  assert.match(
+    page,
+    /<h3 id="nested-label-https-example-com-and-code">[^<]*<a class="anchor"[^>]*>#<\/a><strong>Nested <a href="https:\/\/example\.com">label<\/a><\/strong> and <code>code<\/code><\/h3>/,
+  );
+});


### PR DESCRIPTION
## Summary

- derive documentation TOC entries from renderer-owned heading facts instead of reparsing generated HTML
- escape heading labels once at the TOC sink
- generate deterministic page-wide unique IDs for duplicate headings
- add built-site regressions for malicious text, nested markup, code spans, links, entities, and duplicate anchors
- route the docs-site regression through `make test` before the Swift suite

## Root cause

The docs builder rendered headings to HTML, then used sequential regular expressions to remove the anchor and remaining tags before rendering the TOC. That second parsing path could reconstruct multi-character markup boundaries, double-escape normal heading entities, and generate duplicate IDs for repeated headings.

The renderer now records each heading's level, final ID, and plain label while producing the heading HTML. The TOC consumes those structured facts directly, so heading HTML, labels, and IDs have one owner and no generated-HTML sanitizer.

This rebuilds the useful direction from https://github.com/openclaw/imsg/pull/241 on current `main` without its unrelated changelog or workflow changes.

## Regression proof

- applying only `scripts/build-docs-site.test.mjs` to pre-fix `main` makes both tests fail
- the malicious-heading case exposes double-escaped TOC text from the old HTML-reparse path
- the duplicate-heading case exposes repeated heading IDs and TOC targets from the old slug path

## Verification

- exact commit: `5f760270e3d0ef10b5022091693e35eb93c3437f`
- clean `git archive HEAD` proof with Node `v26.7.0`
- `node --check scripts/build-docs-site.mjs`
- `node --check scripts/build-docs-site.test.mjs`
- `node --test scripts/build-docs-site.test.mjs` (2 passed)
- `make docs-site`
- clean-archive `dist/docs-site/index.html` and `dist/docs-site/send.html` are nonempty
- `make test` (683 tests passed, with the docs-site regression first)
- `make lint` (0 serious violations; 16 existing warnings)
- `make build ARCHES="$(uname -m)"`
- pre-amend Sol/high autoreview: clean, 0.99 confidence
- amended branch Sol/high autoreview: clean, 0.98 confidence
- separate independent Codex review: clean

- exact-head macOS CI: passed
- exact-head Linux read-core CI: passed
- exact-head CodeQL for JavaScript/TypeScript, Swift, and Actions: passed
- exact-head ClawSweeper re-review: no correctness or security findings

## Scope

- production: `scripts/build-docs-site.mjs` `+51/-30` (net `+21`)
- tests: `scripts/build-docs-site.test.mjs` `+100/-0`
- test support: `Makefile` `+2/-1`
- total: 3 files, `+153/-31`
- no dependency, workflow, configuration, changelog, or generated SQLite changes
- generated SQLite.swift alerts 4-11 remain out of scope

CodeQL alert: https://github.com/openclaw/imsg/security/code-scanning/3
