### PR TITLE
chore(deps): update phone metadata and CI toolchains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   macos:
     runs-on: macos-26
     env:
-      SWIFTLINT_VERSION: 0.65.0
+      SWIFTLINT_VERSION: 0.65.1
     steps:
       - uses: actions/checkout@v7
       - name: macOS version

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "24"
+          node-version: "26"
 
       - name: Build docs site
         run: make docs-site

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Let headless `watch` and `search` start without waiting for an undetermined Contacts permission prompt while preserving interactive prompting (#238, thanks @SebTardif).
 
+### Maintenance
+
+- Update PhoneNumberKit to 5.0.7, the CI SwiftLint pin to 0.65.1, and the docs build runtime to Node 26.
+
 ## 0.14.1 - 2026-08-11
 
 **Highlight:** search now finds messages whose text lives only in the rich-text

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3b4b8fcc219563b7f4bea10a00c2ede7c4c4bd385bfd1cf2337a20a1256b3180",
+  "originHash" : "507c9e98ff3b67d55824b5ebb4dd7392b8c8006a20e5ff692513cd293438b6a4",
   "pins" : [
     {
       "identity" : "commander",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/PhoneNumberKit/PhoneNumberKit.git",
       "state" : {
-        "revision" : "e18a029dbada1d8eb32e3f81a4eb72eba539ff75",
-        "version" : "5.0.6"
+        "revision" : "754d0d5597593ba8bcdc2b4ddf5f85fc3a4e799f",
+        "version" : "5.0.7"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/steipete/Commander.git", from: "0.2.4"),
     .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.16.0"),
-    .package(url: "https://github.com/PhoneNumberKit/PhoneNumberKit.git", from: "5.0.6"),
+    .package(url: "https://github.com/PhoneNumberKit/PhoneNumberKit.git", from: "5.0.7"),
   ],
   targets: {
     var targets: [Target] = [

--- a/Tests/imsgTests/RichLinkPreparerTests.swift
+++ b/Tests/imsgTests/RichLinkPreparerTests.swift
@@ -136,19 +136,22 @@ func richLinkPreparerDropsMultiFrameImages() async throws {
   #expect(staged.withValue { $0 } == false)
 }
 
-@Test
+@Test(.timeLimit(.minutes(1)))
 func richLinkPreparerCancellationDoesNotWaitForCancellationIgnoringLoader() async throws {
   typealias Continuation = CheckedContinuation<RichLinkFetchedMetadata?, Never>
   let continuation = RichLinkTestBox<Continuation?>(nil)
-  let loaderStarted = RichLinkTestBox(false)
+  let loaderStarted = AsyncStream<Void>.makeStream()
   let staged = RichLinkTestBox(false)
   let task = Task {
     try await RichLinkPreparer.prepare(
       "https://example.com",
+      // Outlast the test limit so the deadline cannot hide broken cancellation.
+      timeout: .seconds(120),
       loadMetadata: { _ in
         return await withCheckedContinuation { pending in
           continuation.withValue { $0 = pending }
-          loaderStarted.withValue { $0 = true }
+          loaderStarted.continuation.yield(())
+          loaderStarted.continuation.finish()
         }
       },
       stageImage: { _ in
@@ -158,14 +161,10 @@ func richLinkPreparerCancellationDoesNotWaitForCancellationIgnoringLoader() asyn
     )
   }
 
-  let clock = ContinuousClock()
-  let waitDeadline = clock.now.advanced(by: .seconds(1))
-  while !loaderStarted.withValue({ $0 }), clock.now < waitDeadline {
-    try await Task.sleep(for: .milliseconds(1))
+  for await _ in loaderStarted.stream {
+    break
   }
-  #expect(loaderStarted.withValue { $0 })
 
-  let cancelledAt = clock.now
   task.cancel()
   do {
     _ = try await task.value
@@ -175,13 +174,13 @@ func richLinkPreparerCancellationDoesNotWaitForCancellationIgnoringLoader() asyn
   } catch {
     Issue.record("unexpected error: \(error)")
   }
-  let elapsed = cancelledAt.duration(to: clock.now)
-  continuation.withValue { pending in
-    pending?.resume(returning: nil)
-    pending = nil
+  // Cancellation must return while the cancellation-ignoring loader is suspended.
+  let pendingLoader = continuation.withValue { pending in
+    defer { pending = nil }
+    return pending
   }
+  try #require(pendingLoader).resume(returning: nil)
 
-  #expect(elapsed < .seconds(1))
   #expect(staged.withValue { $0 } == false)
 }
 


### PR DESCRIPTION
Update the phone-number dependency and CI tooling, with a separate test-only fix for a cancellation timing failure found during validation.

## Updates

- SwiftPM: PhoneNumberKit 5.0.6 → 5.0.7 in the manifest and resolved lockfile. Commander 0.2.4 and SQLite.swift 0.16.0 are already current.
- CI tooling: SwiftLint 0.65.0 → 0.65.1; docs build runtime Node 24 → 26, validated with Node 26.8.1.
- Add an Unreleased maintenance entry.
- Separate `fix(ci)` commit: replace the rich-link cancellation test's one-second scheduler threshold with a loader-start signal and a check that cancellation returns before releasing the suspended loader. Its metadata deadline exceeds the test timeout, so deadline fallback cannot mask broken cancellation. No production Swift code changes.

## Held pins and baseline CI

The shared release-workflow hotfix pin remains at `6ecd9e5`: the latest `v1`/v1.7.5 tag is 13 commits behind it, and upstream main diverges. Switching would lose release fixes. Other GitHub Actions and the stable Linux Swift 6.3.3 toolchain are current. No other upgrades were held, and no open Dependabot/Renovate PRs are superseded.

Main's [CI](https://github.com/openclaw/imsg/actions/runs/33087586328), [CodeQL](https://github.com/openclaw/imsg/actions/runs/33087585586), and [pages](https://github.com/openclaw/imsg/actions/runs/31565587750) are green. The historical [Release failure](https://github.com/openclaw/imsg/actions/runs/31455886087) occurred after successful publication/Homebrew handoff: GitHub denied creation of the next Unreleased PR. The repository setting now allows Actions to create PRs; no permission change or release rerun is included.

## Validation

- `swift package update`: resolved all three dependencies successfully.
- `make lint`: passed with SwiftLint 0.65.1; 16 warnings, 0 serious violations across 237 files.
- `make test`: final run passed all 671 tests (393 CLI + 278 core). The initial run had one cancellation timing failure at 1.161 seconds; the focused regression and the full suite passed after the test-only fix.
- `make build`: universal arm64/x86_64 CLI and arm64e/arm64/x86_64 helper succeeded.
- Built CLI `--help`, native `--version`, and x86_64 `--version` smoke checks passed, reporting 0.14.1.
- `make docs-site` on checksum-verified Node 26.8.1: 19 HTML pages generated; both JavaScript syntax checks passed.
- `actionlint` and `git diff --check`: passed.
- Codex autoreview: no actionable findings at its default P0 threshold.

Local Swift validation used Apple Swift 6.4; the PR workflow additionally runs the Linux Swift 6.3.3 lane. No release, merge, or issue closure is requested.
