### PR TITLE
fix: recover stale direct chat targets before dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Recover missing live direct-chat objects through the verified participant on the original account before dispatch, for CLI and RPC sends (#244, thanks @0xble).
 - Let headless `watch` and `search` start without waiting for an undetermined Contacts permission prompt while preserving interactive prompting (#238, thanks @SebTardif).
 
 ### Maintenance

--- a/Sources/IMsgCore/DirectParticipantTarget.swift
+++ b/Sources/IMsgCore/DirectParticipantTarget.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// A database-verified direct conversation, bound to its original account.
+public struct DirectParticipantTarget: Sendable, Equatable {
+  public let chatGUID: String
+  public let recipient: String
+  public let accountID: String
+  public let service: MessageService
+
+  public init?(chat: ChatInfo, participants: [String]) {
+    let parts = chat.guid.split(separator: ";", omittingEmptySubsequences: false)
+    guard
+      parts.count == 3, parts[1] == "-", parts[2] == chat.identifier,
+      !chat.identifier.isEmpty, participants == [chat.identifier],
+      let accountID = chat.accountID?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !accountID.isEmpty,
+      let service = MessageService(rawValue: chat.service.lowercased()), service != .auto,
+      parts[0].lowercased() == chat.service.lowercased() || parts[0] == "any"
+    else { return nil }
+    self.chatGUID = chat.guid
+    self.recipient = chat.identifier
+    self.accountID = accountID
+    self.service = service
+  }
+}

--- a/Sources/IMsgCore/MessageSender.swift
+++ b/Sources/IMsgCore/MessageSender.swift
@@ -15,6 +15,7 @@ public struct MessageSendOptions: Sendable {
   public var chatIdentifier: String
   public var chatGUID: String
   public var allowSMSFallback: Bool
+  public var directParticipantTarget: DirectParticipantTarget?
 
   public init(
     recipient: String,
@@ -24,7 +25,8 @@ public struct MessageSendOptions: Sendable {
     region: String = "US",
     chatIdentifier: String = "",
     chatGUID: String = "",
-    allowSMSFallback: Bool = true
+    allowSMSFallback: Bool = true,
+    directParticipantTarget: DirectParticipantTarget? = nil
   ) {
     self.recipient = recipient
     self.text = text
@@ -34,6 +36,7 @@ public struct MessageSendOptions: Sendable {
     self.chatIdentifier = chatIdentifier
     self.chatGUID = chatGUID
     self.allowSMSFallback = allowSMSFallback
+    self.directParticipantTarget = directParticipantTarget
   }
 }
 
@@ -159,6 +162,9 @@ public struct MessageSender {
     smsFallbackEligible: Bool
   ) throws {
     let script = appleScript()
+    let directTarget = resolved.directParticipantTarget.flatMap {
+      $0.chatGUID == chatTarget ? $0 : nil
+    }
     func arguments(forService service: MessageService, forceBuddy: Bool = false) -> [String] {
       [
         resolved.recipient,
@@ -168,6 +174,9 @@ public struct MessageSender {
         resolved.attachmentPath.isEmpty ? "0" : "1",
         chatTarget,
         useChat && !forceBuddy ? "1" : "0",
+        directTarget?.accountID ?? "",
+        directTarget?.recipient ?? "",
+        directTarget?.service.rawValue ?? "",
       ]
     }
 
@@ -195,10 +204,27 @@ public struct MessageSender {
           set useAttachment to item 5 of argv
           set chatId to item 6 of argv
           set useChat to item 7 of argv
+          set directAccountID to item 8 of argv
+          set directRecipient to item 9 of argv
+          set directService to item 10 of argv
 
           tell application "Messages"
               if useChat is "1" then
-                  set targetChat to chat id chatId
+                  -- Resolve eagerly; only this lookup may recover before dispatch.
+                  try
+                      set targetChat to get chat id chatId
+                  on error lookupMessage number lookupNumber
+                      if lookupNumber is not -1728 or directAccountID is "" then
+                          error number lookupNumber
+                      end if
+                      set targetAccount to get account id directAccountID
+                      if directService is "imessage" then
+                          if (service type of targetAccount) is not iMessage then error number -1728
+                      else
+                          if (service type of targetAccount) is not SMS then error number -1728
+                      end if
+                      set targetChat to get buddy directRecipient of targetAccount
+                  end try
                   if theMessage is not "" then
                       set dispatchPhase to "dispatch_started"
                       send theMessage to targetChat

--- a/Sources/imsg/ChatTargetResolver.swift
+++ b/Sources/imsg/ChatTargetResolver.swift
@@ -130,6 +130,23 @@ enum ChatTargetResolver {
     return true
   }
 
+  static func directParticipantTarget(
+    store: MessageStore?,
+    resolvedTarget: ResolvedChatTarget,
+    directChatInfo: ChatInfo?
+  ) -> DirectParticipantTarget? {
+    guard let store else { return nil }
+    let chat =
+      directChatInfo
+      ?? resolvedTarget.preferredIdentifier.flatMap {
+        try? store.chatInfo(matchingExactTarget: $0)
+      }
+    guard let chat, let participants = try? store.participants(chatID: chat.id) else {
+      return nil
+    }
+    return DirectParticipantTarget(chat: chat, participants: participants)
+  }
+
   static func resolveRecipientName(
     _ recipient: String,
     contacts: any ContactResolving

--- a/Sources/imsg/Commands/SendCommand.swift
+++ b/Sources/imsg/Commands/SendCommand.swift
@@ -160,7 +160,9 @@ enum SendCommand {
       region: region,
       chatIdentifier: input.hasChatTarget ? resolvedTarget.chatIdentifier : "",
       chatGUID: input.hasChatTarget ? resolvedTarget.chatGUID : (directChatInfo?.guid ?? ""),
-      allowSMSFallback: allowSMSFallback
+      allowSMSFallback: allowSMSFallback,
+      directParticipantTarget: ChatTargetResolver.directParticipantTarget(
+        store: store, resolvedTarget: resolvedTarget, directChatInfo: directChatInfo)
     )
     let sentAt = Date()
     try sendMessage(options)

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -262,7 +262,9 @@ extension RPCServer {
       region: region,
       chatIdentifier: input.hasChatTarget ? resolvedTarget.chatIdentifier : "",
       chatGUID: input.hasChatTarget ? resolvedTarget.chatGUID : (directChatInfo?.guid ?? ""),
-      allowSMSFallback: allowSMSFallback
+      allowSMSFallback: allowSMSFallback,
+      directParticipantTarget: ChatTargetResolver.directParticipantTarget(
+        store: database?.store, resolvedTarget: resolvedTarget, directChatInfo: directChatInfo)
     )
     let sentAt = Date()
 

--- a/Tests/IMsgCoreTests/DirectParticipantTargetTests.swift
+++ b/Tests/IMsgCoreTests/DirectParticipantTargetTests.swift
@@ -1,0 +1,50 @@
+import Testing
+
+@testable import IMsgCore
+
+private func participantTarget(
+  guid: String = "iMessage;-;friend@example.com",
+  participants: [String] = ["friend@example.com"],
+  accountID: String? = "test-account",
+  service: String = "iMessage"
+) -> DirectParticipantTarget? {
+  DirectParticipantTarget(
+    chat: ChatInfo(
+      id: 1, identifier: "friend@example.com", guid: guid, name: "", service: service,
+      accountID: accountID),
+    participants: participants)
+}
+
+@Test
+func directParticipantTargetRequiresVerifiedDirectMembershipAndAccount() {
+  #expect(participantTarget()?.recipient == "friend@example.com")
+  #expect(participantTarget()?.accountID == "test-account")
+  #expect(participantTarget()?.service == .imessage)
+  #expect(participantTarget(guid: "any;-;friend@example.com") != nil)
+  #expect(participantTarget(guid: "iMessage;+;friend@example.com") == nil)
+  #expect(participantTarget(guid: "iMessage;-;different@example.com") == nil)
+  #expect(participantTarget(guid: "SMS;-;friend@example.com") == nil)
+  #expect(participantTarget(participants: []) == nil)
+  #expect(participantTarget(participants: ["other@example.com"]) == nil)
+  #expect(participantTarget(participants: ["friend@example.com", "other@example.com"]) == nil)
+  #expect(participantTarget(accountID: nil) == nil)
+  #expect(participantTarget(accountID: "  ") == nil)
+  #expect(participantTarget(service: "RCS") == nil)
+}
+
+@Test
+func directParticipantTargetIsBoundToOriginalChat() throws {
+  var captured: [String] = []
+  let sender = MessageSender(runner: { _, arguments in captured = arguments })
+  let target = try #require(participantTarget())
+  try sender.send(
+    MessageSendOptions(
+      recipient: "", text: "hello", chatGUID: target.chatGUID,
+      directParticipantTarget: target))
+  #expect(Array(captured[7...]) == ["test-account", "friend@example.com", "imessage"])
+  try sender.send(
+    MessageSendOptions(
+      recipient: "", text: "hello", chatGUID: "iMessage;+;group",
+      directParticipantTarget: target))
+  #expect(Array(captured[7...]) == ["", "", ""])
+}

--- a/Tests/IMsgCoreTests/MessageSenderDirectParticipantTests.swift
+++ b/Tests/IMsgCoreTests/MessageSenderDirectParticipantTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+
+#if os(macOS)
+  // Execute the production AppleScript control flow, replacing only Messages
+  // operations so the regression tests never dispatch a real message.
+  private func runDirectChatScript(
+    lookupError: Int = -1728,
+    sendError: Int = 0,
+    account: String = "test-account",
+    text: String = "hello",
+    attachment: Bool = false,
+    accountError: Int = 0,
+    smsAccount: Bool = false
+  ) throws -> String {
+    var source = ""
+    var arguments: [String] = []
+    try MessageSender(runner: {
+      source = $0
+      arguments = $1
+    }).send(
+      MessageSendOptions(
+        recipient: "friend@example.com", text: text, service: .imessage,
+        chatGUID: "iMessage;-;friend@example.com", allowSMSFallback: false))
+    arguments = Array(arguments.prefix(7)) + [account, "friend@example.com", "imessage"]
+    if attachment {
+      arguments[3] = "/tmp/synthetic-attachment"
+      arguments[4] = "1"
+    }
+    let substitutions = [
+      ("tell application \"Messages\"", "using terms from application \"Messages\""),
+      ("end tell", "end using terms from"),
+      ("set targetChat to get chat id chatId", "set targetChat to my lookupChat()"),
+      ("set targetChat to chat id chatId", "set targetChat to my lookupChat()"),
+      ("get account id directAccountID", "my lookupAccount()"),
+      ("service type of targetAccount", "my accountService()"),
+      ("get buddy directRecipient of targetAccount", "\"participant\""),
+      ("send theMessage to targetChat", "my dispatchMessage(targetChat)"),
+      ("send theFile to targetChat", "my dispatchMessage(targetChat)"),
+      ("POSIX file theFilePath as alias", "theFilePath"),
+    ]
+    for (original, replacement) in substitutions {
+      source = source.replacingOccurrences(of: original, with: replacement)
+    }
+    source = source.replacingOccurrences(
+      of: "& tab & \"0\"", with: "& tab & \"0\" & \"|\" & dispatchCount & \"|\" & targetKind")
+    source += """
+
+      property dispatchCount : 0
+      property targetKind : "none"
+      on lookupChat()
+          if \(lookupError) is not 0 then error number \(lookupError)
+          return "chat"
+      end lookupChat
+      on lookupAccount()
+          if \(accountError) is not 0 then error number \(accountError)
+          return "account"
+      end lookupAccount
+      on accountService()
+          using terms from application "Messages"
+              return \(smsAccount ? "SMS" : "iMessage")
+          end using terms from
+      end accountService
+      on dispatchMessage(targetValue)
+          set dispatchCount to dispatchCount + 1
+          set targetKind to targetValue
+          if \(sendError) is not 0 then error number \(sendError)
+      end dispatchMessage
+      """
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+    process.arguments = ["-l", "AppleScript", "-"] + arguments
+    let input = Pipe()
+    let output = Pipe()
+    let errors = Pipe()
+    process.standardInput = input
+    process.standardOutput = output
+    process.standardError = errors
+    try process.run()
+    try input.fileHandleForWriting.write(contentsOf: Data(source.utf8))
+    try input.fileHandleForWriting.close()
+    let timedOut = ProcessTimeout.waitUntilExit(process, timeout: 10)
+    #expect(!timedOut)
+    let diagnostic = String(
+      decoding: errors.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    #expect(process.terminationStatus == 0, "\(diagnostic)")
+    return String(decoding: output.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  @Test
+  func staleDirectChatUsesParticipantBeforeDispatch() throws {
+    #expect(try runDirectChatScript() == "IMSG_RESULT\tok\tcompleted\t0|1|participant")
+  }
+
+  @Test
+  func liveChatKeepsChatRouting() throws {
+    #expect(try runDirectChatScript(lookupError: 0) == "IMSG_RESULT\tok\tcompleted\t0|1|chat")
+  }
+
+  @Test
+  func staleDirectChatSendsTextAndAttachmentOnceEach() throws {
+    #expect(
+      try runDirectChatScript(attachment: true) == "IMSG_RESULT\tok\tcompleted\t0|2|participant")
+    #expect(
+      try runDirectChatScript(text: "", attachment: true)
+        == "IMSG_RESULT\tok\tcompleted\t0|1|participant")
+  }
+
+  @Test
+  func unverifiedChatDoesNotRecover() throws {
+    #expect(try runDirectChatScript(account: "") == "IMSG_RESULT\tfailure\tnot_started\t-1728")
+  }
+
+  @Test
+  func otherLookupErrorsDoNotRecover() throws {
+    #expect(
+      try runDirectChatScript(lookupError: -1743) == "IMSG_RESULT\tfailure\tnot_started\t-1743")
+  }
+
+  @Test
+  func participantRecoveryPreservesAccountAndService() throws {
+    #expect(
+      try runDirectChatScript(accountError: -1728) == "IMSG_RESULT\tfailure\tnot_started\t-1728")
+    #expect(
+      try runDirectChatScript(smsAccount: true) == "IMSG_RESULT\tfailure\tnot_started\t-1728")
+  }
+
+  @Test(arguments: [0, -1728])
+  func dispatchErrorsNeverRecover(lookupError: Int) throws {
+    #expect(
+      try runDirectChatScript(lookupError: lookupError, sendError: -1728)
+        == "IMSG_RESULT\tfailure\tmay_have_completed\t-1728")
+  }
+#endif

--- a/Tests/IMsgCoreTests/UtilityTests.swift
+++ b/Tests/IMsgCoreTests/UtilityTests.swift
@@ -385,11 +385,12 @@ func messageSenderBuildsArguments() throws {
       region: "US"
     )
   )
-  #expect(captured.count == 7)
+  #expect(captured.count == 10)
   #expect(captured[0] == "+16502530000")
   #expect(captured[2] == "imessage")
   #expect(captured[5].isEmpty)
   #expect(captured[6] == "0")
+  #expect(Array(captured[7...]) == ["", "", ""])
 }
 
 @Test

--- a/Tests/imsgTests/DirectParticipantRoutingTests.swift
+++ b/Tests/imsgTests/DirectParticipantRoutingTests.swift
@@ -1,0 +1,57 @@
+import Commander
+import Foundation
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+@Test(arguments: ["to", "chatID", "chatGUID", "chatIdentifier"])
+func sendCommandSuppliesVerifiedParticipantRoute(target: String) async throws {
+  let path = try CommandTestDatabase.makePathDirectChat()
+  let targetValue = target == "to" ? "+123" : (target == "chatID" ? "1" : "iMessage;-;+123")
+  let values = ParsedValues(
+    positional: [], options: ["db": [path], target: [targetValue], "text": ["hello"]],
+    flags: ["noSMSFallback"])
+  var captured: MessageSendOptions?
+  _ = try await StdoutCapture.capture {
+    try await SendCommand.run(
+      values: values, runtime: RuntimeOptions(parsedValues: values),
+      sendMessage: { captured = $0 }, resolveSentMessage: resolvedSentMessageFixture)
+  }
+  #expect(captured?.directParticipantTarget?.chatGUID == "iMessage;-;+123")
+  #expect(captured?.directParticipantTarget?.recipient == "+123")
+  #expect(captured?.directParticipantTarget?.accountID == "iMessage;+;me@icloud.com")
+  #expect(captured?.allowSMSFallback == false)
+}
+
+@Test(arguments: ["to", "chat_id", "chat_guid", "chat_identifier"])
+func rpcSuppliesVerifiedParticipantRoute(target: String) async throws {
+  let path = try CommandTestDatabase.makePathDirectChat()
+  let store = try MessageStore(path: path)
+  let output = TestRPCOutput()
+  var captured: MessageSendOptions?
+  let server = RPCServer(
+    store: store, verbose: false, output: output,
+    sendMessage: { captured = $0 }, resolveSentMessage: resolvedSentMessageFixture)
+  let targetValue: Any = target == "to" ? "+123" : (target == "chat_id" ? 1 : "iMessage;-;+123")
+  let request: [String: Any] = [
+    "jsonrpc": "2.0", "id": 1, "method": "send",
+    "params": [target: targetValue, "text": "hello", "transport": "applescript"],
+  ]
+  await server.handleLineForTesting(
+    String(decoding: try JSONSerialization.data(withJSONObject: request), as: UTF8.self))
+  #expect(output.errors.isEmpty)
+  #expect(captured?.directParticipantTarget?.chatGUID == "iMessage;-;+123")
+  #expect(captured?.directParticipantTarget?.recipient == "+123")
+  #expect(captured?.directParticipantTarget?.accountID == "iMessage;+;me@icloud.com")
+}
+
+@Test
+func groupWithOneRemainingParticipantDoesNotGetDirectRoute() throws {
+  let store = try MessageStore(path: CommandTestDatabase.makePath())
+  #expect(
+    ChatTargetResolver.directParticipantTarget(
+      store: store,
+      resolvedTarget: ResolvedChatTarget(chatIdentifier: "", chatGUID: "iMessage;+;chat123"),
+      directChatInfo: nil) == nil)
+}

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -521,6 +521,11 @@ Params (chat target):
 `to` and chat selectors are mutually exclusive. Direct sends require `to` and
 no chat selector; chat-target sends require exactly one selector and no `to`.
 
+AppleScript sends use the same [direct-chat recovery](send.md#direct-sends) as
+the CLI: a missing live chat can resolve through its verified participant on
+the original account, before dispatch. This does not change service and is
+independent of `allow_sms_fallback`.
+
 Result:
 
 ```json

--- a/docs/send.md
+++ b/docs/send.md
@@ -26,6 +26,16 @@ When `chat.db` is readable and the recipient already has a direct chat, `imsg`
 targets that chat's GUID instead of constructing a new buddy send. New
 recipients still use the existing buddy-send behavior.
 
+If that GUID is absent from Messages.app's live chats, `imsg` recovers from
+the pre-dispatch `-1728` lookup error by resolving the participant on the
+chat's original account. This requires a direct-chat GUID, exactly one matching
+database participant, and a known account with the same service. It also works
+for direct conversations selected with `--chat-id`, `--chat-guid`, or
+`--chat-identifier`. Groups and unverified targets never use this recovery.
+Errors during `send` still have an uncertain outcome and are never retried.
+This account-scoped recovery does not change service and is independent of
+`--no-sms-fallback`.
+
 ## Group sends
 
 You'll typically want `--chat-id`:
@@ -70,7 +80,7 @@ imsg send --to "+14155551212" --text "hi" --no-sms-fallback
 - `imessage` — force iMessage. Fails fast if the recipient isn't on iMessage.
 - `sms` — force SMS relay. Requires Text Message Forwarding enabled on your iPhone for this Mac.
 
-Fallback is intentionally narrow: it does not run for explicit `--service imessage`, `--service sms`, chat-target sends, email recipients, or attachment sends. For groups, omit `--service`. Group sends always use the chat's existing service.
+SMS fallback is intentionally narrow: it does not run for explicit `--service imessage`, `--service sms`, explicit chat-target sends, email recipients, or attachment sends. For groups, omit `--service`. Group sends always use the chat's existing service.
 
 Failed mutations report one of three delivery dispositions: `not_started`
 (retry is safe), `may_have_completed` (outcome unknown; do not retry), or


### PR DESCRIPTION
Fixes #244.

A direct conversation in SQLite does not guarantee that its GUID exists in Messages.app's live AppleScript chats. Both `send --to` and explicit chat selectors could therefore choose an unavailable chat object. The sender had no same-account participant recovery, and its chat reference was not eagerly resolved before dispatch began.

This change resolves `get chat id` before the first send. Only a `-1728` from that lookup can recover through the original account's participant. The shared CLI/RPC resolver supplies recovery metadata only when the database has a direct GUID, exactly one matching participant, and a known account and service. The transport binds this metadata to the selected GUID and checks the live account's service. Groups and unverified targets do not gain participant recovery. Errors during or after send remain uncertain and never retry through this path. Existing SMS fallback controls are unchanged.

The changelog and CLI/RPC docs describe the behavior. No new CLI flag or RPC parameter is needed.

Validation:

- Reproduced the original `IMSG_RESULT / failure / not_started / -1728` in the production AppleScript under real `osascript`, substituting only the Messages operations.
- `make test`: 683 tests passed (396 CLI/RPC, 287 core), including 12 new regression tests. These cover all four CLI and RPC selectors, verified membership, groups with one remaining participant, account/service mismatches, attachments, and post-dispatch failures. The AppleScript tests execute the production control flow under `osascript` without sending real messages.
- `make lint`: passed; 16 existing warnings, zero serious violations. `make docs-site` and `git diff --check` passed.
- `make build`: passed for the arm64/x86_64 universal CLI and arm64e/arm64/x86_64 helper. Native and Rosetta version checks passed.
- The built CLI read a synthetic SQLite chat and exercised `--to`, `--chat-id`, and `--chat-guid`; each stopped at a deliberately nonexistent account with `not_started / -1728`. A real debug-binary RPC invocation returned the matching structured disposition and `retry_safe: true`.
- Live Messages.app target-resolution probe on macOS 26.6.2: synthetic GUID absent from live chats; same-account recovery resolved a participant; missing-account and group controls returned `not_started / -1728`.
- Codex autoreview passed with no actionable findings at its default P0 threshold.

Proof limitation: no real message delivery was attempted. Live checks used synthetic identifiers and nonexistent accounts, or removed all send statements before exercising the live target lookup. Zero messages were dispatched. The first full test run found an existing seven-argument assertion; it was updated for the three new metadata arguments, and the full rerun passed.
