### PR TITLE
fix: do not prompt Contacts for headless nickname --local

### DIFF
--- a/Sources/imsg/Commands/BridgeIntroCommands.swift
+++ b/Sources/imsg/Commands/BridgeIntroCommands.swift
@@ -277,6 +277,11 @@ enum WhoisCommand {
 // MARK: - nickname
 
 enum NicknameCommand {
+  /// Same TTY rule as RPC: headless stdin must not prompt for Contacts.
+  static func contactsAccessPolicy(stdinIsTTY: Bool) -> ContactsAccessPolicy {
+    .forStdin(isTTY: stdinIsTTY)
+  }
+
   static let spec = CommandSpec(
     name: "nickname",
     abstract: "Show contact-card / nickname info for a handle",
@@ -313,7 +318,10 @@ enum NicknameCommand {
     values: ParsedValues,
     runtime: RuntimeOptions,
     contactResolverFactory: @escaping (String) async -> any ContactResolving = { region in
-      await ContactResolver.create(region: region)
+      await ContactResolver.create(
+        region: region,
+        accessPolicy: contactsAccessPolicy(stdinIsTTY: ContactsAccessPolicy.stdinIsTTY)
+      )
     }
   ) async throws {
     guard let addr = values.option("address"), !addr.isEmpty else {

--- a/Tests/imsgTests/RpcCommandContactsPolicyTests.swift
+++ b/Tests/imsgTests/RpcCommandContactsPolicyTests.swift
@@ -55,3 +55,16 @@ struct SearchCommandContactsPolicyTests {
     #expect(SearchCommand.contactsAccessPolicy(stdinIsTTY: true) == .requestIfNeeded)
   }
 }
+
+@Suite("NicknameCommand Contacts policy")
+struct NicknameCommandContactsPolicyTests {
+  @Test("nickname --local uses skipIfNotDetermined when stdin is not a TTY")
+  func headlessLocalSkipsUndetermined() {
+    #expect(NicknameCommand.contactsAccessPolicy(stdinIsTTY: false) == .skipIfNotDetermined)
+  }
+
+  @Test("nickname --local keeps requestIfNeeded on interactive stdin")
+  func interactiveLocalRequestsIfNeeded() {
+    #expect(NicknameCommand.contactsAccessPolicy(stdinIsTTY: true) == .requestIfNeeded)
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Merged [#238](https://github.com/openclaw/imsg/pull/238) taught CLI `watch` and `search` the same TTY-aware Contacts rule as `imsg rpc` ([#187](https://github.com/openclaw/imsg/pull/187), issue [#186](https://github.com/openclaw/imsg/issues/186)). `imsg nickname --local` was left on the default factory:

```swift
await ContactResolver.create(region: region)
```

That still uses `.requestIfNeeded`. When Contacts authorization is `.notDetermined`, the call awaits `CNContactStore.requestAccess`. A headless (non-TTY) `imsg nickname --address … --local` can hang on a TCC prompt that never resolves. `chats` and `history` already skip ([#136](https://github.com/openclaw/imsg/pull/136)). `imsg send` still prompts, because name targets need Contacts.

## Evidence

### Prior art (same repo)

- [#136](https://github.com/openclaw/imsg/pull/136) added `ContactsAccessPolicy.skipIfNotDetermined` for `imsg chats` and `imsg history`.
- [#187](https://github.com/openclaw/imsg/pull/187) applied a TTY-aware rule to `imsg rpc`.
- [#238](https://github.com/openclaw/imsg/pull/238) moved that rule onto `ContactsAccessPolicy.forStdin(isTTY:)` and wired watch plus search. Nickname `--local` still called `create(region:)` without an access policy.

### Fix

`NicknameCommand` now uses `ContactsAccessPolicy.forStdin(isTTY:)` in the `--local` factory, the same helper as search, watch, and RPC. Interactive terminals still request access. `imsg send` is unchanged.

### Live headless nickname --local (after fix)

Environment: macOS 26.6.2 (Build 25G83), arm64, Contacts authorization **notDetermined** (raw `0`), patched debug binary, stdin from `/dev/null` (not a TTY).

```console
$ swift -e 'import Contacts; print(CNContactStore.authorizationStatus(for: .contacts).rawValue)'
0

$ python3 -c 'import os; print("stdin_isatty", os.isatty(0))'
stdin_isatty False

$ ./.build/debug/imsg nickname --address +15551234567 --local --json </dev/null
{"address":"+15551234567","local_contact_name":"","found":false,"source":"local-addressbook","contacts_unavailable":true}
```

Elapsed 0.354s, exit 0. Contacts authorization was still raw `0` after the command, so the process did not prompt or change TCC state.

## Real behavior proof

- **Behavior or issue addressed:** Headless `imsg nickname --address … --local` no longer requests Contacts when authorization is notDetermined, so automation does not hang on a TCC prompt.
- **Real environment tested:** macOS 26.6.2 (Build 25G83), arm64, Contacts authorization raw 0 (notDetermined), patched `imsg` at `/tmp/oc-pr-imsg-F005/.build/debug/imsg`, stdin from `/dev/null`.
- **Exact steps or command run after this patch:**

  ```bash
  swift -e 'import Contacts; print(CNContactStore.authorizationStatus(for: .contacts).rawValue)'
  ./.build/debug/imsg nickname --address +15551234567 --local --json </dev/null
  swift -e 'import Contacts; print(CNContactStore.authorizationStatus(for: .contacts).rawValue)'
  ```

- **Evidence after fix:** terminal output from the patched binary:

  ```console
  $ swift -e 'import Contacts; print(CNContactStore.authorizationStatus(for: .contacts).rawValue)'
  0

  $ ./.build/debug/imsg nickname --address +15551234567 --local --json </dev/null
  {"address":"+15551234567","local_contact_name":"","found":false,"source":"local-addressbook","contacts_unavailable":true}

  $ swift -e 'import Contacts; print(CNContactStore.authorizationStatus(for: .contacts).rawValue)'
  0
  ```

  The command returned in 0.354s with `contacts_unavailable: true`. Authorization stayed 0.

- **Observed result after fix:** Headless nickname `--local` completed without a Contacts prompt while authorization was still notDetermined. The JSON payload reports `contacts_unavailable: true` instead of blocking.
- **What was not tested:** Interactive TTY prompt path (no TCC dialog was shown). Granted or denied Contacts states. Linux, where `ContactResolver.create` already returns `NoOpContactResolver`.

## Summary

Leftover from [#238](https://github.com/openclaw/imsg/pull/238): `nickname --local` now shares `ContactsAccessPolicy.forStdin`. Introduced with `--local` in [#132](https://github.com/openclaw/imsg/pull/132) (2026-05-29).
