### PR TITLE
chore(deps): update PhoneNumberKit to 5.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Dependencies
+
+- Update PhoneNumberKit to 5.0.8 for current phone-number metadata.
+
 ## 0.14.2 - 2026-08-28
 
 ### Highlights

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/PhoneNumberKit/PhoneNumberKit.git",
       "state" : {
-        "revision" : "754d0d5597593ba8bcdc2b4ddf5f85fc3a4e799f",
-        "version" : "5.0.7"
+        "revision" : "cf2f1df6f2fe8b49701f4b43f0e97c7bd113d034",
+        "version" : "5.0.8"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/steipete/Commander.git", from: "0.2.4"),
     .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.16.0"),
-    .package(url: "https://github.com/PhoneNumberKit/PhoneNumberKit.git", from: "5.0.7"),
+    .package(url: "https://github.com/PhoneNumberKit/PhoneNumberKit.git", from: "5.0.8"),
   ],
   targets: {
     var targets: [Target] = [


### PR DESCRIPTION
Refresh PhoneNumberKit from 5.0.7 to 5.0.8, updating phone-number metadata from 9.0.37 to 9.0.38. Raise the manifest minimum, regenerate `Package.resolved` with SwiftPM, and document the user-visible metadata refresh in the changelog. Upstream changes only metadata resources; no API migration is required.

Dependency audit:

- PhoneNumberKit 5.0.7 → 5.0.8 ([upstream release](https://github.com/PhoneNumberKit/PhoneNumberKit/releases/tag/5.0.8)).
- Commander 0.2.4 and SQLite.swift 0.16.0 are already current. No major updates are pending.
- All referenced Actions, SwiftLint 0.65.1, and the Swift 6.3.3 Linux image are current.
- Retain the immutable release-workflow hotfix pin: the latest stable v1/v1.7.5 tag is 13 commits behind it and would lose required release fixes. Newer default-branch changes concern ownership/docs, not a newer compatible release.

Validation on macOS with Apple Swift 6.4 / Xcode 27:

- `make lint`: passed; 16 existing non-fatal SwiftLint warnings, zero serious violations.
- `make test`: passed; 396 CLI tests + 287 core tests + 2 docs-site tests.
- `make docs-site`: `built docs site: dist/docs-site`.
- `actionlint` and `git diff --check`: passed.
- Codex autoreview: scoped-clean at the skill's default P0 threshold, with no accepted/actionable findings.

CI reasoning: the initial NORUNS observation does not reflect the build/test state; the recent-run list is dominated by operational ClawSweeper dispatches. The actual default-branch [macOS/Linux build-and-test CI](https://github.com/openclaw/imsg/actions/runs/33231699352) and [docs deployment](https://github.com/openclaw/imsg/actions/runs/33231699377) are green at base commit `63b7780`. ClawSweeper is event dispatch, Crabbox Hydrate is manual test infrastructure, and Release is manually dispatched publication; these are distinct from build/test CI. This PR changes no workflows and requires no production action.

This PR is for orchestrator review and landing; no merge or release is performed by this maintenance task.

Full release build and actual-binary proof (commands run from the checkout):

```text
$ make build
Build complete! (188.19 sec)
Build complete! (409.01 sec)

$ ./bin/imsg --version
0.14.2
$ lipo -archs bin/imsg
x86_64 arm64
$ lipo -archs bin/imsg-bridge-helper.dylib
x86_64 arm64 arm64e
```

Real Messages database read, reporting only aggregate/schema validation so no private chat content or identifiers are published:

```sh
set -o pipefail
./bin/imsg chats --limit 3 --json | jq -s -e '{chat_count:length, valid: (length > 0 and all(.[]; (.id|type) == "number" and (.identifier|length) > 0))}'
```

```json
{
  "chat_count": 3,
  "valid": true
}
```

Additional synthetic Messages-database integration proof, using a local SQLite fixture containing one chat and one message:

```sh
./bin/imsg history --db .build/maintenance-proof/chat.db --chat-id 1 --json
```

```json
{"sender":"deps-proof@example.invalid","guid":"deps-proof-message","is_group":false,"created_at":"2026-08-28T12:00:00.000Z","text":"PhoneNumberKit 5.0.8 integration proof","id":1,"chat_identifier":"deps-proof@example.invalid","chat_id":1,"chat_guid":"iMessage;-;deps-proof@example.invalid","is_from_me":false,"participants":["deps-proof@example.invalid"],"reactions":[],"chat_name":"Dependency proof","attachments":[]}
```

Both debug and universal release binaries passed these read checks. Builds emitted existing upstream/platform deprecation warnings, with no errors.

PR verification: [CI run 33365900821](https://github.com/openclaw/imsg/actions/runs/33365900821) passed at `ca4bdc852206b5603277b7c2a55b49f391b3f533`: macOS lint, full tests, and release build (2m49s); Linux read-core tests and CLI build (1m22s). No CI retries or assertion changes were needed.

The managed [CodeQL run 33365899808](https://github.com/openclaw/imsg/actions/runs/33365899808) also passed for Swift, JavaScript/TypeScript, and Actions. Swift analysis completed in 22m19s, consistent with recent successful default-branch runs. All validation runs completed without retries.
