### PR TITLE
fix: show chat-name fallbacks and Contacts diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fall back to raw chat identifiers for empty display names and distinguish unavailable Contacts from unmatched local nicknames (#250, thanks @riverr4t).
+
 ### Dependencies
 
 - Update PhoneNumberKit to 5.0.8 for current phone-number metadata.

--- a/Sources/IMsgCore/MessageStore+Chats.swift
+++ b/Sources/IMsgCore/MessageStore+Chats.swift
@@ -24,7 +24,7 @@ private struct ListChatsQuery {
     let unreadSelection = UnreadChatSelection(enabled: unreadOnly)
     if schema.hasChatMessageJoinMessageDateColumn {
       self.sql = """
-        SELECT c.ROWID AS chat_rowid, IFNULL(c.display_name, c.chat_identifier) AS name,
+        SELECT c.ROWID AS chat_rowid, IFNULL(NULLIF(c.display_name, ''), c.chat_identifier) AS name,
                c.chat_identifier AS chat_identifier, c.service_name AS service_name,
                MAX(cmj.message_date) AS last_date,
                \(routing.accountIDColumn) AS account_id,
@@ -39,7 +39,7 @@ private struct ListChatsQuery {
         """
     } else {
       self.sql = """
-        SELECT c.ROWID AS chat_rowid, IFNULL(c.display_name, c.chat_identifier) AS name,
+        SELECT c.ROWID AS chat_rowid, IFNULL(NULLIF(c.display_name, ''), c.chat_identifier) AS name,
                c.chat_identifier AS chat_identifier, c.service_name AS service_name,
                MAX(m.date) AS last_date,
                \(routing.accountIDColumn) AS account_id,
@@ -127,7 +127,8 @@ private struct ChatInfoQuery {
     let routing = ChatRoutingSelection(schema: schema)
     self.sql = """
       SELECT c.ROWID AS chat_rowid, IFNULL(c.chat_identifier, '') AS identifier, IFNULL(c.guid, '') AS guid,
-             IFNULL(c.display_name, c.chat_identifier) AS name, IFNULL(c.service_name, '') AS service,
+             IFNULL(NULLIF(c.display_name, ''), c.chat_identifier) AS name,
+             IFNULL(c.service_name, '') AS service,
              \(routing.accountIDColumn) AS account_id,
              \(routing.accountLoginColumn) AS account_login,
              \(routing.lastAddressedHandleColumn) AS last_addressed_handle

--- a/Sources/IMsgCore/MessageStore+Chats.swift
+++ b/Sources/IMsgCore/MessageStore+Chats.swift
@@ -125,10 +125,10 @@ private struct ChatInfoQuery {
 
   init(chatID: ChatID, schema: MessageStoreSchema) {
     let routing = ChatRoutingSelection(schema: schema)
+    // ChatInfo.name also backs JSON display_name; preserve stored empty titles.
     self.sql = """
       SELECT c.ROWID AS chat_rowid, IFNULL(c.chat_identifier, '') AS identifier, IFNULL(c.guid, '') AS guid,
-             IFNULL(NULLIF(c.display_name, ''), c.chat_identifier) AS name,
-             IFNULL(c.service_name, '') AS service,
+             IFNULL(c.display_name, c.chat_identifier) AS name, IFNULL(c.service_name, '') AS service,
              \(routing.accountIDColumn) AS account_id,
              \(routing.accountLoginColumn) AS account_login,
              \(routing.lastAddressedHandleColumn) AS last_addressed_handle

--- a/Sources/imsg/Commands/BridgeIntroCommands.swift
+++ b/Sources/imsg/Commands/BridgeIntroCommands.swift
@@ -333,8 +333,13 @@ enum NicknameCommand {
           "contacts_unavailable": contacts.contactsUnavailable,
         ])
       } else {
+        let missingName = contacts.contactsUnavailable ? "(Contacts unavailable)" : "(none)"
         StdoutWriter.writeLine(
-          "local_contact_name: \(name ?? "(none)") (source=local-addressbook)")
+          "local_contact_name: \(name ?? missingName) (source=local-addressbook)")
+        if contacts.contactsUnavailable {
+          StdoutWriter.writeLine(
+            "Check System Settings > Privacy & Security > Contacts for the app running imsg.")
+        }
       }
       return
     }

--- a/Tests/IMsgCoreTests/MessageStoreListChatsTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreListChatsTests.swift
@@ -65,3 +65,40 @@ func listChatsUsesChatMessageJoinDateWithoutMessageJoinWhenAvailable() throws {
   #expect(chats.first?.accountLogin == nil)
   #expect(chats.first?.lastAddressedHandle == nil)
 }
+
+@Test(arguments: [false, true])
+func chatNamesFallBackForEmptyAndNullDisplayNames(hasJoinDate: Bool) throws {
+  let db = try Connection(.inMemory)
+  try db.execute(
+    """
+    CREATE TABLE chat (
+      ROWID INTEGER PRIMARY KEY, chat_identifier TEXT, guid TEXT,
+      display_name TEXT, service_name TEXT
+    );
+    CREATE TABLE message (ROWID INTEGER PRIMARY KEY, date INTEGER);
+    CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);
+    INSERT INTO chat VALUES
+      (1, 'empty@example.invalid', 'iMessage;-;empty@example.invalid', '', 'iMessage'),
+      (2, 'null@example.invalid', 'iMessage;-;null@example.invalid', NULL, 'iMessage'),
+      (3, 'chat123', 'iMessage;+;chat123', 'Study Group', 'iMessage');
+    INSERT INTO message VALUES (1, 100), (2, 200), (3, 300);
+    INSERT INTO chat_message_join VALUES (1, 1), (2, 2), (3, 3);
+    """
+  )
+  if hasJoinDate {
+    try db.execute(
+      """
+      ALTER TABLE chat_message_join ADD COLUMN message_date INTEGER;
+      UPDATE chat_message_join SET message_date = message_id * 100;
+      """
+    )
+  }
+
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let chats = try store.listChats(limit: 3)
+  #expect(chats.map(\.name) == ["Study Group", "null@example.invalid", "empty@example.invalid"])
+  for chat in chats {
+    let info = try #require(try store.chatInfo(chatID: chat.id))
+    #expect(info.name == chat.name)
+  }
+}

--- a/Tests/IMsgCoreTests/MessageStoreListChatsTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreListChatsTests.swift
@@ -99,6 +99,6 @@ func chatNamesFallBackForEmptyAndNullDisplayNames(hasJoinDate: Bool) throws {
   #expect(chats.map(\.name) == ["Study Group", "null@example.invalid", "empty@example.invalid"])
   for chat in chats {
     let info = try #require(try store.chatInfo(chatID: chat.id))
-    #expect(info.name == chat.name)
+    #expect(info.name == (chat.id == 1 ? "" : chat.name))
   }
 }

--- a/Tests/imsgTests/AccountNicknameLocalCommandTests.swift
+++ b/Tests/imsgTests/AccountNicknameLocalCommandTests.swift
@@ -140,6 +140,31 @@ func nicknameLocalJsonReportsFoundFalseWhenUnknown() async throws {
   #expect(payload["contacts_unavailable"] as? Bool == true)
 }
 
+@Test(arguments: [false, true])
+func nicknameLocalTextDistinguishesUnavailableContacts(contactsUnavailable: Bool) async throws {
+  let values = ParsedValues(
+    positional: [],
+    options: ["address": ["contact@example.invalid"]],
+    flags: ["local"]
+  )
+  let resolver = MockContactResolver(names: [:], contactsUnavailable: contactsUnavailable)
+  let (output, _) = try await StdoutCapture.capture {
+    try await NicknameCommand.run(
+      values: values,
+      runtime: RuntimeOptions(parsedValues: values),
+      contactResolverFactory: { _ in resolver }
+    )
+  }
+  if contactsUnavailable {
+    #expect(output.contains("local_contact_name: (Contacts unavailable)"))
+    #expect(output.contains("Privacy & Security > Contacts"))
+    #expect(!output.contains("(none)"))
+  } else {
+    #expect(output.contains("local_contact_name: (none)"))
+    #expect(!output.contains("Contacts unavailable"))
+  }
+}
+
 @Test
 func nicknameLocalRequiresAddress() async {
   let values = ParsedValues(

--- a/Tests/imsgTests/ChatNamePayloadTests.swift
+++ b/Tests/imsgTests/ChatNamePayloadTests.swift
@@ -1,0 +1,65 @@
+import Commander
+import Foundation
+import SQLite
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+@Test(arguments: [false, true])
+func chatListJSONPreservesEmptyTitle(hasJoinDate: Bool) async throws {
+  let path = try CommandTestDatabase.makePathDirectChat()
+  defer { try? FileManager.default.removeItem(atPath: path) }
+  let db = try Connection(path)
+  try configureEmptyChatTitle(db, hasJoinDate: hasJoinDate)
+  let values = ParsedValues(positional: [], options: ["db": [path]], flags: ["jsonOutput"])
+  let (output, _) = try await StdoutCapture.capture {
+    try await ChatsCommand.run(
+      values: values,
+      runtime: RuntimeOptions(parsedValues: values),
+      contactResolverFactory: { NoOpContactResolver(contactsUnavailable: true) }
+    )
+  }
+  let line = try #require(output.split(separator: "\n").first)
+  let chat = try #require(try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+  #expect(chat["name"] as? String == "+123")
+  #expect(chat["display_name"] as? String == "")
+  #expect(chat["identifier"] as? String == "+123")
+}
+
+@Test(arguments: [false, true])
+func rpcChatListPreservesEmptyTitle(hasJoinDate: Bool) async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
+  try store.withConnection { db in
+    try configureEmptyChatTitle(db, hasJoinDate: hasJoinDate)
+  }
+  // Reopen after schema changes so the query chooses the matching date layout.
+  let refreshed = try store.withConnection { db in
+    try MessageStore(connection: db, path: ":memory:")
+  }
+  let output = TestRPCOutput()
+  let server = RPCServer(
+    store: refreshed, verbose: false, output: output,
+    contactResolver: NoOpContactResolver(contactsUnavailable: true)
+  )
+  await server.handleLineForTesting(
+    #"{"jsonrpc":"2.0","id":1,"method":"chats.list","params":{"limit":1}}"#
+  )
+  let result = try #require(output.responses.first?["result"] as? [String: Any])
+  let chat = try #require((result["chats"] as? [[String: Any]])?.first)
+  #expect(chat["name"] as? String == "+123")
+  #expect(chat["display_name"] as? String == "")
+  #expect(chat["identifier"] as? String == "+123")
+}
+
+private func configureEmptyChatTitle(_ db: Connection, hasJoinDate: Bool) throws {
+  try db.run("UPDATE chat SET display_name = '' WHERE ROWID = 1")
+  if hasJoinDate {
+    try db.execute(
+      """
+      ALTER TABLE chat_message_join ADD COLUMN message_date INTEGER;
+      UPDATE chat_message_join SET message_date = 100;
+      """
+    )
+  }
+}

--- a/docs/chats.md
+++ b/docs/chats.md
@@ -20,6 +20,8 @@ display name or raw chat identifier.
 Empty and missing Messages display names fall back to the raw chat identifier,
 including when Contacts is unavailable over SSH. JSON exposes a resolved Contacts
 match separately as `contact_name` in both `chats` and RPC `chats.list`.
+The presentation fallback belongs to `name`: an empty stored title remains empty
+in JSON `display_name` and chat-detail metadata.
 
 ## Inspect one chat
 
@@ -40,7 +42,7 @@ Objects returned by `imsg chats --json` and JSON-RPC `chats.list` include:
 |-------|------|-------|
 | `id` | int | `chat.ROWID`. Stable within one Messages database. Preferred routing handle. |
 | `name` | string | Messages display name or raw chat identifier fallback. |
-| `display_name` | string | Chat detail display name, with the same raw-identifier fallback. |
+| `display_name` | string | Chat title metadata. An empty stored title remains empty. |
 | `contact_name` | string | Resolved Contacts name when permission granted. |
 | `identifier` | string | `chat.chat_identifier` — Messages' portable handle. |
 | `guid` | string | `chat.guid` — Messages' portable GUID. |

--- a/docs/chats.md
+++ b/docs/chats.md
@@ -14,7 +14,12 @@ imsg chats --limit 20 --json | jq -s
 
 Columns (text mode): `id`, `name`, `service`, `last_message_at`.
 
-`name` is the resolved display name when available — group title, contact match, or raw handle as a fallback.
+Text output prefers a resolved contact name for direct chats, then the Messages
+display name or raw chat identifier.
+
+Empty and missing Messages display names fall back to the raw chat identifier,
+including when Contacts is unavailable over SSH. JSON exposes a resolved Contacts
+match separately as `contact_name` in both `chats` and RPC `chats.list`.
 
 ## Inspect one chat
 
@@ -34,8 +39,8 @@ Objects returned by `imsg chats --json` and JSON-RPC `chats.list` include:
 | Field | Type | Notes |
 |-------|------|-------|
 | `id` | int | `chat.ROWID`. Stable within one Messages database. Preferred routing handle. |
-| `name` | string | Display name, contact match, or raw handle fallback. |
-| `display_name` | string | `chat.display_name` (group title) when set. |
+| `name` | string | Messages display name or raw chat identifier fallback. |
+| `display_name` | string | Chat detail display name, with the same raw-identifier fallback. |
 | `contact_name` | string | Resolved Contacts name when permission granted. |
 | `identifier` | string | `chat.chat_identifier` — Messages' portable handle. |
 | `guid` | string | `chat.guid` — Messages' portable GUID. |

--- a/docs/json.md
+++ b/docs/json.md
@@ -20,7 +20,7 @@ Returned by `imsg chats --json` and JSON-RPC `chats.list`.
 | Field | Type | Notes |
 |-------|------|-------|
 | `id` | int | `chat.ROWID`. Stable within one DB. Preferred routing handle. |
-| `name` | string | Display name, contact match, or raw handle fallback. |
+| `name` | string | Messages display name or raw chat identifier fallback. |
 | `display_name` | string | Group title from `chat.display_name`. Empty for direct chats without a custom name. |
 | `contact_name` | string | Resolved Contacts name (when permission granted). |
 | `identifier` | string | `chat.chat_identifier`. Portable. |

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -52,6 +52,13 @@ When granted, `imsg` resolves names from your Address Book and includes them as 
 
 Grant it under **System Settings → Privacy & Security → Contacts**.
 
+`imsg nickname --local` distinguishes `(Contacts unavailable)` from `(none)` in
+text output; JSON exposes the same distinction as `contacts_unavailable`. An
+unavailable result means imsg could not read Contacts, not that the handle has no
+matching contact. For SSH and other indirect launches, check the Contacts grant
+for the app or process running imsg. Full Disk Access alone does not grant Contacts
+access.
+
 If you skip this, JSON output simply leaves the resolved name fields empty. Nothing else changes. A long-running `imsg rpc` child observes Contacts changes and periodically rechecks authorization, so grants and contact edits become visible without restarting. Revocation clears cached names; a transient Contacts read failure retains the last successful catalog until the next refresh.
 
 On Macs with CardDAV accounts such as Google or Yahoo, Apple's Contacts framework may periodically write `Could not fetch group … :ABGroup` reconciliation messages to stderr. These messages are benign and do not come from `imsg`; a parent process that captures `imsg rpc --json` stderr should not report this specific framework message as an `imsg` error.


### PR DESCRIPTION
Empty Messages display names currently leave `chats` and RPC `chats.list` with a blank presentation `name`: SQL `IFNULL` handles NULL but preserves `""`. Treat empty names like NULL in both list-query layouts so `name` falls back to the chat identifier. Preserve the existing chat-detail path and its stable JSON/RPC `display_name` contract: an empty stored title stays empty.

Local nickname text now distinguishes `(Contacts unavailable)` from `(none)` and points to the parent app's Contacts permission. Its existing JSON fields are unchanged. Regression tests cover both database layouts, empty/NULL/named chats, CLI and RPC payloads, and unavailable versus unmatched nickname output. The docs distinguish presentation names from title metadata and explain the existing `contact_name` field.

Addresses the reporting bugs in #250. Direct AddressBook SQLite access remains a separate privacy/product decision. #248 independently repairs the headless Contacts prompt hang.

Validation on `74c699758cf148b46976e004324590697a2868e9`:

- [CI run 33369355616](https://github.com/openclaw/imsg/actions/runs/33369355616) passed macOS lint, standard `make test`, and release build, plus Linux read-core tests and CLI build.
- Local `make lint` passed with 16 existing warnings and zero serious violations; `git diff --check` passed.
- Codex autoreview of the complete corrected diff is scoped-clean at its configured P0 threshold.
- The rebuilt, Developer ID–signed CLI passed synthetic SQLite integration through both chat-list layouts, chat detail, nickname text/JSON, and a real stdio RPC request. A process-local sandbox denied Contacts access without changing saved macOS permissions.

Proof commands, run against the signed binary and synthetic fixture databases:

```sh
sandbox-exec -f contacts-unavailable.sb ./imsg chats --db legacy.db --json
sandbox-exec -f contacts-unavailable.sb ./imsg chats --db modern.db --json
sandbox-exec -f contacts-unavailable.sb ./imsg group --db modern.db --chat-id 1 --json
sandbox-exec -f contacts-unavailable.sb ./imsg nickname --local --address contact@example.invalid
sandbox-exec -f contacts-unavailable.sb ./imsg nickname --local --address contact@example.invalid --json
printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"chats.list","params":{"limit":3}}' | sandbox-exec -f contacts-unavailable.sb ./imsg rpc --db modern.db
```

Each fixture contains an empty-title chat, a NULL-title chat, and a titled chat. The modern layout adds `chat_message_join.message_date`. The test-process sandbox is:

```scheme
(version 1)
(allow default)
(deny mach-lookup (global-name "com.apple.tccd") (global-name "com.apple.contactsd"))
```

Observed fields for the empty-title chat in both CLI and RPC:

```text
0.14.2: name="", display_name=""
patched: name="contact1@example.invalid", display_name=""
```

Chat-detail metadata stays empty. The NULL-title row retains its existing identifier fallback; the titled row remains `Fixture Group`.

Nickname text changes from:

```text
local_contact_name: (none) (source=local-addressbook)
```

to:

```text
local_contact_name: (Contacts unavailable) (source=local-addressbook)
Check System Settings > Privacy & Security > Contacts for the app running imsg.
```

Both versions emit `contacts_unavailable: true, found: false` in nickname JSON. The repair makes that existing distinction visible in text.

The post-push review correctly identified a `display_name` compatibility regression in the preceding revision. This head restores the original metadata path and adds CLI/RPC assertions that specifically prevent it. The local Xcode 27 full-suite rerun stalled during compilation after producing the verified binary and was stopped after the complete CI suite passed; the final full-suite result above is from GitHub CI.
