### PR TITLE
fix: create iMessage handles for first-contact chats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,15 @@ test:
 	swift test
 
 test-helper:
+ifeq ($(shell uname -s),Darwin)
 	@mkdir -p .build/helper-tests
 	clang -fobjc-arc -Wno-arc-performSelector-leaks -Wno-incomplete-implementation \
 		-framework Foundation -framework AppKit -framework ImageIO -framework LinkPresentation \
 		Tests/IMsgHelperTests/ChatCreateTests.m -o .build/helper-tests/chat-create
 	.build/helper-tests/chat-create
+else
+	@echo "Skipping native bridge tests (macOS only)."
+endif
 
 build:
 	scripts/generate-version.sh

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: help format lint test build imsg clean build-dylib docs-site
+.PHONY: help format lint test test-helper build imsg clean build-dylib docs-site
 
 help:
 	@printf "%s\n" \
@@ -22,10 +22,18 @@ lint:
 
 test:
 	node --test scripts/build-docs-site.test.mjs
+	$(MAKE) test-helper
 	scripts/generate-version.sh
 	swift package resolve
 	scripts/patch-deps.sh
 	swift test
+
+test-helper:
+	@mkdir -p .build/helper-tests
+	clang -fobjc-arc -Wno-arc-performSelector-leaks -Wno-incomplete-implementation \
+		-framework Foundation -framework AppKit -framework ImageIO -framework LinkPresentation \
+		Tests/IMsgHelperTests/ChatCreateTests.m -o .build/helper-tests/chat-create
+	.build/helper-tests/chat-create
 
 build:
 	scripts/generate-version.sh

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Normal `chats`, `history`, `watch`, `send`, `react`, and read-only RPC workflows
 
 Read receipts, typing indicators, rich sends, message mutation, stickers, polls, and chat management use an injected helper inside Messages.app. They require SIP to be disabled and may be blocked by library validation or private-entitlement checks on current macOS releases. Start with [Advanced IMCore](docs/advanced-imcore.md), then use the [bridge command reference](docs/bridge.md) for the full CLI surface and IPC layout.
 
+[`imsg chat-create`](docs/chats.md#create-an-imessage-chat) accepts phone numbers and email addresses you have never contacted. It creates missing handles through the active iMessage account and checks every recipient with IDS before creating the chat. You do not need to type recipients into Messages first.
+
 ## Documentation
 
 The complete guide lives at **[imsg.sh](https://imsg.sh)**. Useful entry points include [install](docs/install.md), [permissions](docs/permissions.md), [history](docs/history.md), [watch](docs/watch.md), [send](docs/send.md), [attachments](docs/attachments.md), [Linux](docs/linux.md), and [troubleshooting](docs/troubleshooting.md).

--- a/Sources/IMsgHelper/IMsgInjected.m
+++ b/Sources/IMsgHelper/IMsgInjected.m
@@ -359,6 +359,9 @@ static BOOL readAccountConnected(id account) {
 - (NSArray *)activeAccounts;
 @end
 
+static IMAccount *activeIMessageAccount(void);
+static NSDictionary *handleCheckIMessageAvailability(NSInteger requestId, NSDictionary *params);
+
 @interface IMHandleRegistrar : NSObject
 + (instancetype)sharedInstance;
 - (id)IMHandleWithID:(NSString *)handleID;
@@ -613,7 +616,7 @@ static id handleMatchingService(NSArray *handles, NSString *preferredService) {
 }
 
 static id vendIMHandle(id registrar, NSString *address, NSString *preferredService, BOOL allowFallback) {
-    if (!registrar || ![address isKindOfClass:[NSString class]] || address.length == 0) {
+    if (![address isKindOfClass:[NSString class]] || address.length == 0) {
         return nil;
     }
 
@@ -632,6 +635,16 @@ static id vendIMHandle(id registrar, NSString *address, NSString *preferredServi
             id handle = handleMatchingService(handles, preferredService);
             if (handle) return handle;
             [fallbackHandles addObjectsFromArray:handles];
+        }
+        // The registrar only knows existing handles. Let the active account
+        // canonicalize and create first-contact iMessage handles before falling
+        // back to a cached handle from another service.
+        if ([preferredService caseInsensitiveCompare:@"iMessage"] == NSOrderedSame) {
+            IMAccount *account = activeIMessageAccount();
+            if ([account respondsToSelector:@selector(imHandleWithID:)]) {
+                id handle = [account imHandleWithID:address];
+                if (handle) return handle;
+            }
         }
     } @catch (__unused NSException *ex) {
         return nil;
@@ -6189,7 +6202,6 @@ static NSDictionary *handleCreateChat(NSInteger requestId, NSDictionary *params)
     NSString *requestedService = params[@"service"] ?: @"iMessage";
     NSString *preferredService = @"iMessage";
     NSString *responseService = @"iMessage";
-    BOOL allowHandleFallback = YES;
 
     if (![addresses isKindOfClass:[NSArray class]] || addresses.count == 0) {
         return errorResponse(requestId, @"Missing addresses array");
@@ -6203,7 +6215,6 @@ static NSDictionary *handleCreateChat(NSInteger requestId, NSDictionary *params)
     } else if ([requestedService caseInsensitiveCompare:@"sms"] == NSOrderedSame) {
         preferredService = @"SMS";
         responseService = @"SMS";
-        allowHandleFallback = NO;
     } else {
         return errorResponse(requestId, [NSString stringWithFormat:
             @"Unsupported chat-create service: %@", requestedService]);
@@ -6211,16 +6222,34 @@ static NSDictionary *handleCreateChat(NSInteger requestId, NSDictionary *params)
 
     Class hrClass = NSClassFromString(@"IMHandleRegistrar");
     id hr = hrClass ? [hrClass performSelector:@selector(sharedInstance)] : nil;
-    if (!hr) return errorResponse(requestId, @"IMHandleRegistrar unavailable");
-
     NSMutableArray *handles = [NSMutableArray array];
     for (NSString *addr in addresses) {
-        if (![addr isKindOfClass:[NSString class]]) continue;
-        id h = vendIMHandle(hr, addr, preferredService, allowHandleFallback);
-        if (h) [handles addObject:h];
-    }
-    if (handles.count == 0) {
-        return errorResponse(requestId, @"Could not vend handles for any address");
+        if (![addr isKindOfClass:[NSString class]] || addr.length == 0) {
+            return errorResponse(requestId, @"Each address must be a non-empty phone number or email");
+        }
+        id h = vendIMHandle(hr, addr, preferredService, NO);
+        if (!h) return errorResponse(requestId, [NSString stringWithFormat:
+            @"Could not create %@ handle for %@; check that the account is signed in to Messages",
+            preferredService, addr]);
+        if ([preferredService isEqualToString:@"iMessage"]) {
+            // Vend first: an uncached address is not evidence of IDS reachability.
+            // Validate every participant before the registry can create a chat.
+            NSString *canonicalAddress = [h respondsToSelector:@selector(ID)] ? [h ID] : addr;
+            NSDictionary *check = handleCheckIMessageAvailability(requestId, @{
+                @"address": canonicalAddress ?: addr,
+                @"aliasType": [addr containsString:@"@"] ? @"email" : @"phone"
+            });
+            if (![check[@"success"] boolValue]) return errorResponse(requestId,
+                [NSString stringWithFormat:@"Could not check iMessage availability for %@: %@",
+                 addr, check[@"error"]]);
+            if (![check[@"available"] boolValue]) {
+                NSString *reason = [check[@"id_status"] integerValue] == 2
+                    ? @"is not reachable on iMessage; verify the address or use imsg send --service sms for a phone number"
+                    : @"could not confirm iMessage availability; check the Messages account and connection, then retry";
+                return errorResponse(requestId, [NSString stringWithFormat:@"%@: %@", addr, reason]);
+            }
+        }
+        [handles addObject:h];
     }
 
     Class regClass = NSClassFromString(@"IMChatRegistry");

--- a/Sources/IMsgHelper/IMsgInjected.m
+++ b/Sources/IMsgHelper/IMsgInjected.m
@@ -652,6 +652,23 @@ static id vendIMHandle(id registrar, NSString *address, NSString *preferredServi
     return allowFallback ? fallbackHandles.firstObject : nil;
 }
 
+static NSString *iMessageAvailabilityError(id handle, NSString *address) {
+    // Account-vended handles do not prove reachability. Check their canonical
+    // addresses before group creation or invitation can mutate a conversation.
+    NSString *canonicalAddress = [handle respondsToSelector:@selector(ID)] ? [handle ID] : address;
+    NSDictionary *check = handleCheckIMessageAvailability(0, @{
+        @"address": canonicalAddress ?: address,
+        @"aliasType": [address containsString:@"@"] ? @"email" : @"phone"
+    });
+    if (![check[@"success"] boolValue]) return [NSString stringWithFormat:
+        @"Could not check iMessage availability for %@: %@", address, check[@"error"]];
+    if ([check[@"available"] boolValue]) return nil;
+    NSString *reason = [check[@"id_status"] integerValue] == 2
+        ? @"is not reachable on iMessage; verify the address or use imsg send --service sms for a phone number"
+        : @"could not confirm iMessage availability; check the Messages account and connection, then retry";
+    return [NSString stringWithFormat:@"%@: %@", address, reason];
+}
+
 #pragma mark - Chat Resolution
 
 static NSArray<NSString *>* chatIdentifierPrefixes(void) {
@@ -6011,6 +6028,8 @@ static NSDictionary *handleAddParticipant(NSInteger requestId, NSDictionary *par
     // Match chat-create's fallback-capable iMessage handle lookup.
     id handle = vendIMHandle(hr, address, @"iMessage", YES);
     if (!handle) return errorResponse(requestId, @"Could not vend handle");
+    NSString *availabilityError = iMessageAvailabilityError(handle, address);
+    if (availabilityError) return errorResponse(requestId, availabilityError);
 
     @try {
         // macOS 26 renamed this selector; retain the older spelling as fallback.
@@ -6232,22 +6251,8 @@ static NSDictionary *handleCreateChat(NSInteger requestId, NSDictionary *params)
             @"Could not create %@ handle for %@; check that the account is signed in to Messages",
             preferredService, addr]);
         if ([preferredService isEqualToString:@"iMessage"]) {
-            // Vend first: an uncached address is not evidence of IDS reachability.
-            // Validate every participant before the registry can create a chat.
-            NSString *canonicalAddress = [h respondsToSelector:@selector(ID)] ? [h ID] : addr;
-            NSDictionary *check = handleCheckIMessageAvailability(requestId, @{
-                @"address": canonicalAddress ?: addr,
-                @"aliasType": [addr containsString:@"@"] ? @"email" : @"phone"
-            });
-            if (![check[@"success"] boolValue]) return errorResponse(requestId,
-                [NSString stringWithFormat:@"Could not check iMessage availability for %@: %@",
-                 addr, check[@"error"]]);
-            if (![check[@"available"] boolValue]) {
-                NSString *reason = [check[@"id_status"] integerValue] == 2
-                    ? @"is not reachable on iMessage; verify the address or use imsg send --service sms for a phone number"
-                    : @"could not confirm iMessage availability; check the Messages account and connection, then retry";
-                return errorResponse(requestId, [NSString stringWithFormat:@"%@: %@", addr, reason]);
-            }
+            NSString *availabilityError = iMessageAvailabilityError(h, addr);
+            if (availabilityError) return errorResponse(requestId, availabilityError);
         }
         [handles addObject:h];
     }

--- a/Sources/IMsgHelper/IMsgInjected.m
+++ b/Sources/IMsgHelper/IMsgInjected.m
@@ -615,7 +615,8 @@ static id handleMatchingService(NSArray *handles, NSString *preferredService) {
     return nil;
 }
 
-static id vendIMHandle(id registrar, NSString *address, NSString *preferredService, BOOL allowFallback) {
+static id vendIMHandle(id registrar, NSString *address, NSString *preferredService,
+                      BOOL allowFallback, BOOL createIfMissing) {
     if (![address isKindOfClass:[NSString class]] || address.length == 0) {
         return nil;
     }
@@ -639,7 +640,8 @@ static id vendIMHandle(id registrar, NSString *address, NSString *preferredServi
         // The registrar only knows existing handles. Let the active account
         // canonicalize and create first-contact iMessage handles before falling
         // back to a cached handle from another service.
-        if ([preferredService caseInsensitiveCompare:@"iMessage"] == NSOrderedSame) {
+        if (createIfMissing &&
+            [preferredService caseInsensitiveCompare:@"iMessage"] == NSOrderedSame) {
             IMAccount *account = activeIMessageAccount();
             if ([account respondsToSelector:@selector(imHandleWithID:)]) {
                 id handle = [account imHandleWithID:address];
@@ -1287,7 +1289,8 @@ static IMChat *resolveChatByGuid(NSString *chatGuid) {
     }
 
     // Fallback: parse a direct `<service>;-;<address>` guid and materialize
-    // a chat using only a handle for the explicitly requested service.
+    // a chat using only a registered handle for the explicitly requested service.
+    // First-contact creation belongs to the IDS-checked create/invite handlers.
     NSArray *parts = [chatGuid componentsSeparatedByString:@";"];
     if (parts.count == 3 && [parts[1] isEqualToString:@"-"]) {
         NSString *preferredService = parts.firstObject;
@@ -1295,7 +1298,7 @@ static IMChat *resolveChatByGuid(NSString *chatGuid) {
         Class hrClass = NSClassFromString(@"IMHandleRegistrar");
         if (hrClass) {
             id hr = [hrClass performSelector:@selector(sharedInstance)];
-            id handle = vendIMHandle(hr, address, preferredService, NO);
+            id handle = vendIMHandle(hr, address, preferredService, NO, NO);
             if (handle && [registry respondsToSelector:@selector(chatForIMHandle:)]) {
                 id chat = [registry performSelector:@selector(chatForIMHandle:)
                                          withObject:handle];
@@ -6026,7 +6029,7 @@ static NSDictionary *handleAddParticipant(NSInteger requestId, NSDictionary *par
     Class hrClass = NSClassFromString(@"IMHandleRegistrar");
     id hr = hrClass ? [hrClass performSelector:@selector(sharedInstance)] : nil;
     // Match chat-create's fallback-capable iMessage handle lookup.
-    id handle = vendIMHandle(hr, address, @"iMessage", YES);
+    id handle = vendIMHandle(hr, address, @"iMessage", YES, YES);
     if (!handle) return errorResponse(requestId, @"Could not vend handle");
     NSString *availabilityError = iMessageAvailabilityError(handle, address);
     if (availabilityError) return errorResponse(requestId, availabilityError);
@@ -6246,7 +6249,7 @@ static NSDictionary *handleCreateChat(NSInteger requestId, NSDictionary *params)
         if (![addr isKindOfClass:[NSString class]] || addr.length == 0) {
             return errorResponse(requestId, @"Each address must be a non-empty phone number or email");
         }
-        id h = vendIMHandle(hr, addr, preferredService, NO);
+        id h = vendIMHandle(hr, addr, preferredService, NO, YES);
         if (!h) return errorResponse(requestId, [NSString stringWithFormat:
             @"Could not create %@ handle for %@; check that the account is signed in to Messages",
             preferredService, addr]);

--- a/Sources/imsg/Commands/BridgeChatCommands.swift
+++ b/Sources/imsg/Commands/BridgeChatCommands.swift
@@ -10,8 +10,9 @@ enum ChatCreateCommand {
     abstract: "Create a new chat (1:1 or group)",
     discussion: """
       Requires `imsg launch` (SIP-disabled, dylib injected). Vends handles for
-      each address through Messages' private IMCore API and asks IMChatRegistry
-      to materialize a chat. Optionally sets a display name and sends an
+      each address, including previously uncontacted recipients, through the
+      active iMessage account. Every recipient must pass an IDS availability
+      check before the chat is created. Optionally sets a display name and sends an
       initial message. Chat creation is currently iMessage-only; use
       `imsg send --service sms` for SMS sends.
       """,

--- a/Tests/IMsgHelperTests/ChatCreateTests.m
+++ b/Tests/IMsgHelperTests/ChatCreateTests.m
@@ -1,0 +1,213 @@
+// Exercise the actual bridge handlers with in-process IMCore/IDS stand-ins.
+// Frameworks linked by AppKit can load IDS too. Give the stand-ins unique
+// runtime names so tests cannot call the real IDS controller or collide with it.
+#import <Foundation/Foundation.h>
+static Class testClassFromString(NSString *name) {
+    if ([@[@"IMAccountController", @"IMHandleRegistrar", @"IMChatRegistry", @"IDSIDQueryController"]
+            containsObject:name]) {
+        return NSClassFromString([@"Test" stringByAppendingString:name]);
+    }
+    return NSClassFromString(name);
+}
+#define IMAccountController TestIMAccountController
+#define IMHandleRegistrar TestIMHandleRegistrar
+#define IMChatRegistry TestIMChatRegistry
+#define IDSIDQueryController TestIDSIDQueryController
+#define NSClassFromString testClassFromString
+#import "../../Sources/IMsgHelper/IMsgInjected.m"
+#undef NSClassFromString
+
+@interface TestHandle : NSObject
+@property NSString *ID;
+@property NSString *serviceName;
+@end
+@implementation TestHandle
+@end
+
+static NSMutableDictionary *registeredHandles;
+static NSMutableArray *createdAddresses;
+static NSMutableArray *queriedDestinations;
+static NSArray *chatHandles;
+static NSDictionary *availability;
+static NSString *unvendableAddress;
+static NSDictionary *canonicalAddresses;
+static BOOL accountAvailable;
+static BOOL queryThrows;
+static BOOL secondaryLookup;
+static NSUInteger failures;
+
+static TestHandle *testHandle(NSString *address, NSString *service) {
+    TestHandle *handle = [TestHandle new];
+    handle.ID = address;
+    handle.serviceName = service;
+    return handle;
+}
+
+@interface TestAccount : NSObject
+- (id)imHandleWithID:(NSString *)address;
+@end
+@implementation TestAccount
+- (id)imHandleWithID:(NSString *)address {
+    [createdAddresses addObject:address];
+    return [address isEqual:unvendableAddress] ? nil
+        : testHandle(canonicalAddresses[address] ?: address, @"iMessage");
+}
+@end
+
+@implementation IMAccountController
++ (instancetype)sharedInstance { return [self new]; }
+- (IMAccount *)activeIMessageAccount {
+    return accountAvailable ? (IMAccount *)[TestAccount new] : nil;
+}
+@end
+
+@implementation IMHandleRegistrar
++ (instancetype)sharedInstance { return [self new]; }
+- (id)IMHandleWithID:(NSString *)address {
+    return secondaryLookup ? nil : registeredHandles[address];
+}
+- (id)getIMHandlesForID:(NSString *)address {
+    return registeredHandles[address];
+}
+@end
+
+@interface TestChat : NSObject
+- (NSString *)guid;
+@end
+@implementation TestChat
+- (NSString *)guid { return @"iMessage;+;chat-test"; }
+@end
+
+@implementation IMChatRegistry
++ (instancetype)sharedInstance { return [self new]; }
+- (id)chatForIMHandle:(id)handle { return [self chatForIMHandles:@[handle]]; }
+- (id)chatForIMHandles:(NSArray *)handles {
+    chatHandles = handles;
+    return [TestChat new];
+}
+@end
+
+@implementation IDSIDQueryController
++ (instancetype)sharedInstance { return [self new]; }
+- (NSInteger)_currentIDStatusForDestination:(NSString *)destination
+                                    service:(NSString *)service
+                                 listenerID:(NSString *)listenerID {
+    if (queryThrows) [NSException raise:@"TestQueryFailure" format:@"IDS lookup failed"];
+    NSCAssert([service isEqual:@"com.apple.madrid"], @"Must query the iMessage service");
+    [queriedDestinations addObject:destination];
+    return [availability[destination] integerValue];
+}
+@end
+
+static void resetFixture(void) {
+    registeredHandles = [NSMutableDictionary dictionary];
+    createdAddresses = [NSMutableArray array];
+    queriedDestinations = [NSMutableArray array];
+    chatHandles = nil;
+    availability = @{@"tel:+15550100101": @1, @"tel:+15550100102": @1,
+                     @"mailto:new@example.test": @1};
+    unvendableAddress = nil;
+    canonicalAddresses = @{};
+    accountAvailable = YES;
+    queryThrows = NO;
+    secondaryLookup = NO;
+}
+
+static void check(BOOL condition, NSString *message) {
+    if (condition) return;
+    fprintf(stderr, "FAIL: %s\n", message.UTF8String);
+    failures++;
+}
+
+static NSDictionary *createChat(NSArray *addresses) {
+    return handleCreateChat(1, @{@"addresses": addresses, @"service": @"iMessage"});
+}
+
+static void checkFailure(NSDictionary *result, NSString *message) {
+    check(![result[@"success"] boolValue], message);
+    check(chatHandles == nil, @"Must not create a partial chat on failure");
+}
+
+int main(void) {
+    @autoreleasepool {
+        resetFixture();
+        NSArray *addresses = @[@"+15550100101", @"+15550100102"];
+        NSDictionary *result = createChat(addresses);
+        check([result[@"success"] boolValue], @"Two never-contacted addresses must create a chat");
+        check([createdAddresses isEqual:addresses], @"Missing handles must be created by the active account");
+        check([[chatHandles valueForKey:@"ID"] isEqual:addresses], @"The chat must contain both requested handles");
+        check(queriedDestinations.count == 2, @"Check both recipients with IDS before chat creation");
+
+        for (NSNumber *useSecondary in @[@NO, @YES]) {
+            resetFixture();
+            secondaryLookup = useSecondary.boolValue;
+            id cached = testHandle(addresses[0], @"iMessage");
+            registeredHandles[addresses[0]] = secondaryLookup ? [NSSet setWithObject:cached] : cached;
+            result = createChat(@[addresses[0]]);
+            check([result[@"success"] boolValue] && chatHandles.firstObject == cached,
+                  @"Both registrar selectors must preserve cached handles");
+            check(createdAddresses.count == 0, @"The registrar remains the fast path");
+        }
+
+        resetFixture();
+        registeredHandles[addresses[0]] = testHandle(addresses[0], @"SMS");
+        result = createChat(@[addresses[0]]);
+        check([result[@"success"] boolValue], @"An SMS-only cached handle must allow iMessage creation");
+        check([[(TestHandle *)chatHandles.firstObject serviceName] isEqual:@"iMessage"],
+              @"Never create an iMessage chat with an SMS handle");
+
+        resetFixture();
+        result = createChat(@[@"new@example.test"]);
+        check([result[@"success"] boolValue], @"Unknown email addresses must also work");
+        check([queriedDestinations isEqual:@[@"mailto:new@example.test"]], @"Email IDS queries use mailto");
+
+        resetFixture();
+        canonicalAddresses = @{@"(555) 010-0101": addresses[0]};
+        result = createChat(@[@"(555) 010-0101"]);
+        check([result[@"success"] boolValue], @"Check the account-canonicalized address with IDS");
+        check([queriedDestinations isEqual:@[@"tel:+15550100101"]], @"IDS must receive the canonical phone number");
+
+        resetFixture();
+        registeredHandles[addresses[0]] = testHandle(addresses[0], @"iMessage");
+        unvendableAddress = addresses[1];
+        checkFailure(createChat(addresses), @"A missing second handle must fail instead of creating a direct chat");
+
+        resetFixture();
+        accountAvailable = NO;
+        registeredHandles[addresses[0]] = testHandle(addresses[0], @"SMS");
+        checkFailure(createChat(@[addresses[0]]), @"No iMessage account must not fall back to SMS");
+
+        for (NSNumber *idStatus in @[@0, @2]) {
+            resetFixture();
+            availability = @{@"tel:+15550100101": @1, @"tel:+15550100102": idStatus};
+            for (NSString *address in addresses) {
+                registeredHandles[address] = testHandle(address, @"iMessage");
+            }
+            result = createChat(addresses);
+            checkFailure(result, @"Unconfirmed recipients must fail before creating a chat");
+            check([result[@"error"] containsString:addresses[1]], @"The error must identify the failing address");
+            check([result[@"error"] containsString:idStatus.integerValue == 2 ? @"not reachable" : @"could not confirm"],
+                  @"Distinguish unreachable addresses from unresolved IDS status");
+        }
+
+        resetFixture();
+        registeredHandles[addresses[0]] = testHandle(addresses[0], @"iMessage");
+        queryThrows = YES;
+        checkFailure(createChat(@[addresses[0]]), @"IDS errors must stop chat creation");
+
+        resetFixture();
+        registeredHandles[addresses[0]] = testHandle(addresses[0], @"iMessage");
+        checkFailure(createChat(@[addresses[0], @42]), @"Invalid addresses must not be silently omitted");
+
+        resetFixture();
+        id registrar = [IMHandleRegistrar sharedInstance];
+        check(vendIMHandle(registrar, addresses[0], @"SMS", NO) == nil,
+              @"Explicit SMS resolution must not create an iMessage handle");
+        check(createdAddresses.count == 0, @"SMS lookup must not use the iMessage account");
+        check(vendIMHandle(registrar, addresses[0], @"iMessage", YES) != nil,
+              @"Participant addition also gains unknown-handle creation");
+
+        fprintf(stdout, "Bridge chat-create tests: %lu failure(s)\n", (unsigned long)failures);
+        return failures ? 1 : 0;
+    }
+}

--- a/Tests/IMsgHelperTests/ChatCreateTests.m
+++ b/Tests/IMsgHelperTests/ChatCreateTests.m
@@ -28,6 +28,7 @@ static NSMutableDictionary *registeredHandles;
 static NSMutableArray *createdAddresses;
 static NSMutableArray *queriedDestinations;
 static NSArray *chatHandles;
+static NSArray *invitedHandles;
 static NSDictionary *availability;
 static NSString *unvendableAddress;
 static NSDictionary *canonicalAddresses;
@@ -73,13 +74,20 @@ static TestHandle *testHandle(NSString *address, NSString *service) {
 
 @interface TestChat : NSObject
 - (NSString *)guid;
+- (void)inviteParticipants:(NSArray *)handles reason:(NSInteger)reason;
 @end
 @implementation TestChat
 - (NSString *)guid { return @"iMessage;+;chat-test"; }
+- (void)inviteParticipants:(NSArray *)handles reason:(NSInteger)reason {
+    invitedHandles = handles;
+}
 @end
 
 @implementation IMChatRegistry
 + (instancetype)sharedInstance { return [self new]; }
+- (id)existingChatWithGUID:(NSString *)guid {
+    return [guid isEqual:@"iMessage;+;chat-test"] ? [TestChat new] : nil;
+}
 - (id)chatForIMHandle:(id)handle { return [self chatForIMHandles:@[handle]]; }
 - (id)chatForIMHandles:(NSArray *)handles {
     chatHandles = handles;
@@ -104,6 +112,7 @@ static void resetFixture(void) {
     createdAddresses = [NSMutableArray array];
     queriedDestinations = [NSMutableArray array];
     chatHandles = nil;
+    invitedHandles = nil;
     availability = @{@"tel:+15550100101": @1, @"tel:+15550100102": @1,
                      @"mailto:new@example.test": @1};
     unvendableAddress = nil;
@@ -204,8 +213,29 @@ int main(void) {
         check(vendIMHandle(registrar, addresses[0], @"SMS", NO) == nil,
               @"Explicit SMS resolution must not create an iMessage handle");
         check(createdAddresses.count == 0, @"SMS lookup must not use the iMessage account");
-        check(vendIMHandle(registrar, addresses[0], @"iMessage", YES) != nil,
-              @"Participant addition also gains unknown-handle creation");
+
+        for (NSNumber *idStatus in @[@0, @1, @2]) {
+            resetFixture();
+            availability = @{@"tel:+15550100101": idStatus};
+            result = handleAddParticipant(1, @{
+                @"chatGuid": @"iMessage;+;chat-test", @"address": addresses[0]
+            });
+            if (idStatus.integerValue == 1) {
+                check([result[@"success"] boolValue], @"Reachable first-contact participants can be invited");
+                check([[invitedHandles valueForKey:@"ID"] isEqual:@[addresses[0]]],
+                      @"Invite the account-created participant");
+            } else {
+                check(![result[@"success"] boolValue], @"Reject unconfirmed first-contact invitations");
+                check(invitedHandles == nil, @"IDS negative/unknown results must never reach the invitation selector");
+                check([result[@"error"] containsString:addresses[0]], @"Invitation errors identify the recipient");
+            }
+        }
+
+        resetFixture();
+        queryThrows = YES;
+        result = handleAddParticipant(1, @{@"chatGuid": @"iMessage;+;chat-test", @"address": addresses[0]});
+        check(![result[@"success"] boolValue] && invitedHandles == nil,
+              @"An IDS error must stop participant invitation");
 
         fprintf(stdout, "Bridge chat-create tests: %lu failure(s)\n", (unsigned long)failures);
         return failures ? 1 : 0;

--- a/Tests/IMsgHelperTests/ChatCreateTests.m
+++ b/Tests/IMsgHelperTests/ChatCreateTests.m
@@ -209,9 +209,8 @@ int main(void) {
         checkFailure(createChat(@[addresses[0], @42]), @"Invalid addresses must not be silently omitted");
 
         resetFixture();
-        id registrar = [IMHandleRegistrar sharedInstance];
-        check(vendIMHandle(registrar, addresses[0], @"SMS", NO) == nil,
-              @"Explicit SMS resolution must not create an iMessage handle");
+        result = handleCreateChat(1, @{@"addresses": @[addresses[0]], @"service": @"SMS"});
+        checkFailure(result, @"Explicit SMS creation must not create an iMessage handle");
         check(createdAddresses.count == 0, @"SMS lookup must not use the iMessage account");
 
         for (NSNumber *idStatus in @[@0, @1, @2]) {
@@ -236,6 +235,24 @@ int main(void) {
         result = handleAddParticipant(1, @{@"chatGuid": @"iMessage;+;chat-test", @"address": addresses[0]});
         check(![result[@"success"] boolValue] && invitedHandles == nil,
               @"An IDS error must stop participant invitation");
+
+        resetFixture();
+        check(resolveChatByGuid(@"iMessage;-;+15550100101") == nil,
+              @"Generic direct GUID resolution must not create a first-contact chat");
+        check(createdAddresses.count == 0 && chatHandles == nil,
+              @"Lookup-only commands must not create handles or chats for unknown recipients");
+
+        resetFixture();
+        registeredHandles[addresses[0]] = testHandle(addresses[0], @"iMessage");
+        check(resolveChatByGuid(@"iMessage;-;+15550100101") != nil,
+              @"Generic direct GUID resolution still materializes registered handles");
+        check([[chatHandles valueForKey:@"ID"] isEqual:@[addresses[0]]],
+              @"Registered direct resolution preserves the requested participant");
+
+        resetFixture();
+        registeredHandles[addresses[0]] = testHandle(addresses[0], @"SMS");
+        check(resolveChatByGuid(@"iMessage;-;+15550100101") == nil && chatHandles == nil,
+              @"Direct iMessage resolution must not fall back to a registered SMS handle");
 
         fprintf(stdout, "Bridge chat-create tests: %lu failure(s)\n", (unsigned long)failures);
         return failures ? 1 : 0;

--- a/Tests/imsgTests/BridgeParticipantMutationTests.swift
+++ b/Tests/imsgTests/BridgeParticipantMutationTests.swift
@@ -9,7 +9,6 @@ func participantMutationsUseCurrentAndLegacySelectors() throws {
   let removeBody = try #require(
     participantMutationFunctionBody(named: "handleRemoveParticipant", in: source))
 
-  #expect(addBody.contains(#"vendIMHandle(hr, address, @"iMessage", YES)"#))
   #expect(addBody.contains(#"@"inviteParticipants:reason:""#))
   #expect(addBody.contains(#"@"inviteParticipantsToiMessageChat:reason:""#))
   #expect(removeBody.contains(#"@"removeParticipants:reason:""#))

--- a/Tests/imsgTests/BridgeStickerRegistrationTests.swift
+++ b/Tests/imsgTests/BridgeStickerRegistrationTests.swift
@@ -51,7 +51,6 @@ func injectedHelperWiresStickerSendAction() throws {
   #expect(secureOpenBody.contains("fstat(nextFD, &componentInfo)"))
   #expect(cleanupBody.contains("removeStickerTransferFileSecurely(activePath)"))
   #expect(resolveChatBody.contains(#"[parts[1] isEqualToString:@"-"]"#))
-  #expect(resolveChatBody.contains("vendIMHandle(hr, address, preferredService, NO)"))
 }
 
 @Test

--- a/Tests/imsgTests/README-live.md
+++ b/Tests/imsgTests/README-live.md
@@ -126,7 +126,8 @@ numbers and chat GUIDs out of public test reports.
 
 `make test-helper` runs the actual Objective-C handler against isolated runtime
 stand-ins for cold/cached phone and email handles, mixed services, partial
-resolution, missing accounts, and IDS negative/unknown/error outcomes. It never
+resolution, missing accounts, and IDS negative/unknown/error outcomes for both
+chat creation and participant invitations. It never
 touches the Messages database or sends to recipients. The manual procedure above
 is the separate live private-framework proof; record its outcome when performed.
 

--- a/Tests/imsgTests/README-live.md
+++ b/Tests/imsgTests/README-live.md
@@ -82,6 +82,46 @@ imsg chat-leave --chat "$GROUP"
 
 Expect: each step is visible in Messages.app within a second or two.
 
+### First-contact handle regression
+
+Use two consenting recipients with active iMessage phone numbers that this Mac's
+Messages account has never contacted, looked up, or entered in the New Message
+recipient field. Existing contacts are not a valid first-contact proof. Keep real
+numbers and chat GUIDs out of public test reports.
+
+1. Record `sw_vers`, `imsg --version`, and `imsg status --json`; require SIP disabled
+   and bridge v2 ready. Confirm both recipients are absent from local history with
+   `imsg whois --address "$RECIPIENT_A" --type phone --local --json` (repeat for B).
+   Local history is supporting evidence, not proof that an in-memory handle was
+   never created; the operator must confirm the latter.
+2. With the old helper, run the command below before touching either address in
+   Messages. The reported regression returns `Could not vend handles for any address`.
+3. Build this checkout with `make build` and launch `./bin/imsg launch` so the new
+   sibling helper is injected. Check `./bin/imsg status --json` again. Do not type
+   the addresses in Messages between the old and new runs.
+4. Repeat using the newly built CLI:
+
+   ```bash
+   ./bin/imsg chat-create --addresses "$RECIPIENT_A,$RECIPIENT_B" --json
+   ```
+
+   Expect success, an iMessage `chatGuid`, and both recipients. No `--text` or
+   `--name` is supplied, so this step sends no message or group-name update.
+5. Run `./bin/imsg whois --address "$RECIPIENT_A" --type phone --json` and repeat
+   for B; expect `available=true`. Repeat `chat-create` with the same pair to
+   exercise cached handle reuse. For a visible Messages.app group, send a test
+   message only with the recipients' permission and verify both participants.
+6. Repeat with one recipient replaced by a number confirmed not registered with
+   iMessage. Expect an address-specific `not reachable on iMessage` error and no
+   partial group. IDS status 0 (unknown) must instead report `could not confirm`;
+   it is not evidence that the number lacks iMessage.
+
+`make test-helper` runs the actual Objective-C handler against isolated runtime
+stand-ins for cold/cached phone and email handles, mixed services, partial
+resolution, missing accounts, and IDS negative/unknown/error outcomes. It never
+touches the Messages database or sends to recipients. The manual procedure above
+is the separate live private-framework proof; record its outcome when performed.
+
 ## 5. typing events streaming
 
 ```bash

--- a/Tests/imsgTests/README-live.md
+++ b/Tests/imsgTests/README-live.md
@@ -131,6 +131,10 @@ chat creation and participant invitations. It never
 touches the Messages database or sends to recipients. The manual procedure above
 is the separate live private-framework proof; record its outcome when performed.
 
+The harness also verifies that generic direct-GUID resolution remains limited
+to registered handles: first-contact creation is explicit in `chat-create` and
+`chat-add-member`, where IDS validation precedes group mutation.
+
 ## 5. typing events streaming
 
 ```bash

--- a/Tests/imsgTests/README-live.md
+++ b/Tests/imsgTests/README-live.md
@@ -96,9 +96,17 @@ numbers and chat GUIDs out of public test reports.
    never created; the operator must confirm the latter.
 2. With the old helper, run the command below before touching either address in
    Messages. The reported regression returns `Could not vend handles for any address`.
-3. Build this checkout with `make build` and launch `./bin/imsg launch` so the new
-   sibling helper is injected. Check `./bin/imsg status --json` again. Do not type
-   the addresses in Messages between the old and new runs.
+3. Build this checkout with `make build`, then explicitly reload the helper:
+
+   ```bash
+   ./bin/imsg launch --kill-only
+   ./bin/imsg launch --dylib "$(pwd)/bin/imsg-bridge-helper.dylib"
+   ./bin/imsg status --json
+   ```
+
+   `launch` alone reuses a ready bridge; stopping it first ensures the rebuilt
+   helper is loaded. Do not type the addresses in Messages between the old and
+   new runs.
 4. Repeat using the newly built CLI:
 
    ```bash

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -120,6 +120,8 @@ imsg chat-mark --chat 'iMessage;+;chat0000' --read
 
 `chat-photo` clears the photo when `--file` is omitted. `chat-mark` also accepts `--unread`. `chat-create` creates iMessage chats; SMS sending remains available through the standard `imsg send --service sms` path.
 
+`chat-create` can create handles for previously uncontacted phone numbers and email addresses through the active iMessage account. Every recipient is IDS-checked before creating the chat; an unreachable or unresolved address fails the whole request instead of silently creating a smaller group. No Messages.app recipient-field warm-up is needed. See [chat creation](chats.md#create-an-imessage-chat) for errors and optional name/message behavior.
+
 ## Account and identity
 
 Inspect the active account, local history, and address capabilities:

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -122,6 +122,8 @@ imsg chat-mark --chat 'iMessage;+;chat0000' --read
 
 `chat-create` can create handles for previously uncontacted phone numbers and email addresses through the active iMessage account. Every recipient is IDS-checked before creating the chat; an unreachable or unresolved address fails the whole request instead of silently creating a smaller group. No Messages.app recipient-field warm-up is needed. See [chat creation](chats.md#create-an-imessage-chat) for errors and optional name/message behavior.
 
+`chat-add-member` uses the same handle creation and IDS check. An unreachable or unresolved recipient is rejected before Messages sends a group invitation.
+
 ## Account and identity
 
 Inspect the active account, local history, and address capabilities:

--- a/docs/chats.md
+++ b/docs/chats.md
@@ -94,3 +94,18 @@ imsg chats --json | jq -s 'map(select(.service == "SMS"))'
 ```
 
 For more targeted history queries with date and participant filters, use [`imsg history`](history.md).
+
+## Create an iMessage chat
+
+`chat-create` requires the [injected bridge](bridge.md) on a SIP-disabled Mac with an active iMessage account:
+
+```bash
+imsg chat-create --addresses '+15551111111,+15552222222' --json
+imsg chat-create --addresses 'friend@example.com' --json
+```
+
+Replace the examples with real recipients. Previously uncontacted numbers and email addresses work without adding a contact or entering them in Messages.app's **New Message → To:** field first. The bridge reuses registered iMessage handles, creates missing ones through the active account, and checks their canonical addresses with IDS.
+
+Every address must resolve and have confirmed iMessage availability. If IDS reports a recipient is not reachable, the command names that address and stops before creating, naming, or sending to a chat. An unresolved IDS result produces a separate error asking you to check the account and connection, then retry. A failed recipient is never silently dropped from a group. `chat-create` does not fall back to SMS; use `imsg send --service sms` for an intentional SMS send.
+
+`--name` sets the chat display name; `--text` sends an initial message. Omit both when checking creation without sending a message or group-name update. The result includes `chatGuid` and the requested participants; an empty chat may not appear in the recent-chats list until it has activity.

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -226,6 +226,9 @@ Params:
 - `text` (string, optional initial message)
 
 This bridge-backed method is iMessage-only, matching `imsg chat-create`.
+Previously uncontacted addresses are supported. All recipients must resolve and
+pass the bridge's IDS availability check before chat creation; failures identify
+an unreachable or unresolved address and do not create a partial group.
 
 ### `messages.stats`
 


### PR DESCRIPTION
`chat-create` previously searched only `IMHandleRegistrar`, so a valid iMessage recipient that Messages had never encountered could fail with `Could not vend handles for any address`. A mixed known/unknown group could also silently lose the unknown participant.

Keep both registrar lookups as the fast path, then use the existing active iMessage account's `imHandleWithID:` factory to canonicalize and create missing handles. A shared IDS validation helper checks canonical recipients before chat creation or group invitation. Unreachable addresses receive an address-specific error; unknown IDS status remains distinct from a negative result. Any unresolved participant fails chat creation, and iMessage creation cannot substitute a cached SMS handle. First-contact creation is explicitly enabled only for chat creation and participant invitations; generic direct-GUID resolution retains its registered-handle-only behavior. Handle materialization remains separate from reachability validation; the group mutation handlers own the latter.

README, chat/bridge/RPC docs, CLI help, and the live-test guide describe first-contact support and failure behavior. The live guide includes the two-never-contacted-number reproduction, explicit helper reload, cached repeat, and unreachable-recipient check.

Validation:

- `make lint`: passes (16 existing warnings, no serious violations).
- `make build`: passes; CLI contains arm64/x86_64 and the helper contains arm64e/arm64/x86_64. Built CLI help verified.
- `make test`: passes; 689 Swift tests plus docs-site and native Objective-C handler tests. The native harness runs only on macOS; Linux retains the existing test path.
- The native tests compile the actual helper with isolated IMCore/IDS stand-ins. First-contact creation tests fail against unchanged main and pass with this patch. They cover cold/cached phone and email handles, canonicalization, service selection, missing accounts, partial resolution, and IDS negative/unknown/error outcomes.
- Direct-GUID regressions preserve cold/cached lookup behavior and strict service matching. They replace two source-text assertions tied to the old private helper call signature.
- Invitation regressions failed before the shared IDS gate and now pass: status 0, status 2, and query errors cannot reach the invitation selector, while a reachable first-contact recipient is invited.
- Live selector/type-encoding checks on a SIP-disabled macOS 27 host confirmed `IMAccount.imHandleWithID:`, `activeIMessageAccount`, and the existing synchronous IDS query selector. This verifies the API surface, not end-to-end group creation. No two never-contacted recipients were available for this run; the manual procedure is documented in `Tests/imsgTests/README-live.md`.
- Codex autoreview of the complete candidate: no actionable blocking findings.

ClawSweeper's findings and rank-up moves are addressed: shared IDS validation and negative/unknown invitation regressions cover add-member; explicit creation opt-in and cold/cached/cross-service direct-GUID regressions preserve the generic resolver's previous behavior.

The runtime/CLI change adds 38 net lines for account-owned creation and group-recipient validation; the remaining growth is documentation and regression coverage. No new dependency or configuration is introduced.
