### PR TITLE
fix: resolve Contacts over SSH with Full Disk Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Read commands open the database in SQLite read-only mode. `watch` follows databa
 
 Full Disk Access is required for local database reads. Sending and standard tapbacks also require **Automation → Messages**; Contacts access is optional and only adds resolved names. The [permissions guide](docs/permissions.md) covers parent-process grants and stale TCC entries, while [troubleshooting](docs/troubleshooting.md) maps common failures to their likely gate.
 
+SSH sessions can also resolve contact names through the Mac’s read-only AddressBook database when the SSH service has Full Disk Access and Contacts.framework is unavailable. See [Contacts over SSH](docs/permissions.md#contacts-over-ssh).
+
 For SMS, enable Text Message Forwarding on the paired iPhone. `imsg send` uses Messages.app's AppleScript surface and cannot force a particular outgoing number when several numbers share one Apple ID.
 
 ## JSON and automation

--- a/Sources/IMsgCore/AddressBookContacts.swift
+++ b/Sources/IMsgCore/AddressBookContacts.swift
@@ -1,0 +1,124 @@
+#if os(macOS)
+  import Foundation
+  import SQLite
+  import SQLite3
+
+  enum AddressBookContacts {
+    enum ReadError: Error {
+      case unavailable
+      case busy
+    }
+
+    static var directory: URL {
+      FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent("Library/Application Support/AddressBook", isDirectory: true)
+    }
+
+    // SSH can have Full Disk Access without a Contacts.framework grant. Read the
+    // existing v22 store in place, including its WAL; never copy or modify it.
+    static func load(directory: URL) throws -> [ContactCatalogRecord] {
+      do {
+        let manager = FileManager.default
+        let entries = try manager.contentsOfDirectory(
+          at: directory, includingPropertiesForKeys: nil)
+        var directories: [URL] = []
+        if let sources = entries.first(where: { $0.lastPathComponent == "Sources" }) {
+          directories = try manager.contentsOfDirectory(
+            at: sources, includingPropertiesForKeys: [.isDirectoryKey]
+          )
+          .filter { try $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory == true }
+          .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        }
+        directories.append(directory)
+        let databases = try directories.compactMap { directory -> URL? in
+          // Enumerate instead of fileExists, which hides denied directory access.
+          let files = try manager.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: nil)
+          let versions = files.compactMap { file -> (Int, URL)? in
+            let name = file.lastPathComponent
+            guard name.hasPrefix("AddressBook-v"), name.hasSuffix(".abcddb"),
+              let version = Int(name.dropFirst("AddressBook-v".count).dropLast(".abcddb".count))
+            else { return nil }
+            return (version, file)
+          }
+          guard let newest = versions.max(by: { $0.0 < $1.0 }) else { return nil }
+          // An OS migration can leave an old database behind; never serve stale names from it.
+          guard newest.0 == 22 else { throw ReadError.unavailable }
+          return newest.1
+        }
+        guard !databases.isEmpty else { throw ReadError.unavailable }
+
+        var records: [ContactCatalogRecord] = []
+        for database in databases {
+          records += try loadDatabase(database)
+        }
+        return records
+      } catch SQLite.Result.error(_, let code, _) where code == SQLITE_BUSY || code == SQLITE_LOCKED
+      {
+        throw ReadError.busy
+      } catch {
+        // Missing permissions, files, or required columns invalidate old names;
+        // a partial catalog must not masquerade as a successful read.
+        throw ReadError.unavailable
+      }
+    }
+
+    private static func loadDatabase(_ url: URL) throws -> [ContactCatalogRecord] {
+      let db = try Connection(url.path, readonly: true)
+      db.busyTimeout = 0.25
+      let rows = try db.prepareRowIterator(
+        """
+        SELECT r.Z_PK AS id, r.ZNICKNAME AS nickname, r.ZFIRSTNAME AS first_name,
+               r.ZLASTNAME AS last_name, p.ZFULLNUMBER AS phone, NULL AS email
+        FROM ZABCDRECORD r JOIN ZABCDPHONENUMBER p ON p.ZOWNER = r.Z_PK
+        UNION ALL
+        SELECT r.Z_PK AS id, r.ZNICKNAME AS nickname, r.ZFIRSTNAME AS first_name,
+               r.ZLASTNAME AS last_name, NULL AS phone, e.ZADDRESS AS email
+        FROM ZABCDRECORD r JOIN ZABCDEMAILADDRESS e ON e.ZOWNER = r.Z_PK
+        ORDER BY id, phone, email
+        """, bindings: [])
+      var contacts: [Int64: ContactCatalogRecord] = [:]
+      while let row = try rows.failableNext() {
+        let id = try row.get(Expression<Int64>("id"))
+        let nickname = try row.get(Expression<String?>("nickname")) ?? ""
+        let first = try row.get(Expression<String?>("first_name")) ?? ""
+        let last = try row.get(Expression<String?>("last_name")) ?? ""
+        let name =
+          nickname.isEmpty ? [first, last].filter { !$0.isEmpty }.joined(separator: " ") : nickname
+        guard !name.isEmpty else { continue }
+        if contacts[id] == nil {
+          contacts[id] = ContactCatalogRecord(name: name, phones: [], emails: [])
+        }
+        if let phone = try row.get(Expression<String?>("phone")), !phone.isEmpty {
+          contacts[id]?.phones.append(phone)
+        }
+        if let email = try row.get(Expression<String?>("email")), !email.isEmpty {
+          contacts[id]?.emails.append(email)
+        }
+      }
+      return contacts.keys.sorted().compactMap { contacts[$0] }
+    }
+  }
+
+  extension ContactCatalogSource {
+    func allowingAddressBook(at directory: URL) -> ContactCatalogSource {
+      ContactCatalogSource(
+        authorization: {
+          switch authorization() {
+          case .notDetermined, .unavailable: return .addressBook
+          case let current: return current
+          }
+        },
+        load: {
+          switch authorization() {
+          case .authorized: return try load()
+          case .addressBook, .notDetermined, .unavailable:
+            return try AddressBookContacts.load(directory: directory)
+          case .restricted: throw AddressBookContacts.ReadError.unavailable
+          }
+        },
+        observeChanges: observeChanges
+      )
+    }
+  }
+#endif

--- a/Sources/IMsgCore/ContactCatalog.swift
+++ b/Sources/IMsgCore/ContactCatalog.swift
@@ -4,14 +4,18 @@
 
   enum ContactCatalogAuthorization: Equatable, Sendable {
     case authorized
+    case addressBook
     case notDetermined
     case unavailable
+    case restricted
+
+    var canAttemptRead: Bool { self == .authorized || self == .addressBook }
   }
 
   struct ContactCatalogRecord: Sendable {
     let name: String
-    let phones: [String]
-    let emails: [String]
+    var phones: [String]
+    var emails: [String]
   }
 
   struct ContactCatalogSource: @unchecked Sendable {
@@ -90,31 +94,33 @@
       let region = Self.normalizedRegion(region)
       condition.lock()
       while true {
+        if refreshing {
+          condition.wait()
+          continue
+        }
         let authorization = source.authorization()
-        if authorization != .authorized {
-          if refreshing {
-            condition.wait()
-            continue
-          }
+        if !authorization.canAttemptRead {
           apply(.unauthorized)
           let catalog = regionSnapshot(region)
           condition.unlock()
           return (catalog, true)
         }
-        let authorizationBecameAvailable = !authorizationWasAvailable
-        authorizationWasAvailable = true
-        let shouldRefresh = authorizationBecameAvailable || invalidated || now() >= nextRefreshAt
-        if shouldRefresh, refreshing {
-          condition.wait()
-          continue
-        }
+        let authorizationChanged = lastAuthorization != authorization
+        // Transient failures may retain only a catalog from the same source.
+        if authorizationChanged { apply(.unauthorized) }
+        lastAuthorization = authorization
+        let shouldRefresh = authorizationChanged || invalidated || now() >= nextRefreshAt
         if shouldRefresh {
           refreshing = true
           invalidated = false
           condition.unlock()
           let result = loadCatalog()
           condition.lock()
-          apply(source.authorization() == .authorized ? result : .unauthorized)
+          // A grant change can switch the data source. Discard an in-flight read
+          // from the old source instead of caching it under the new permission.
+          let sourceChanged = source.authorization() != authorization
+          apply(sourceChanged ? .unauthorized : result)
+          if sourceChanged { invalidated = true }
           refreshing = false
           condition.broadcast()
           if invalidated { continue }
@@ -135,12 +141,15 @@
       case loaded([ContactCatalogRecord])
       case transientFailure
       case unauthorized
+      case unavailable
     }
 
     private func loadCatalog() -> LoadResult {
-      guard source.authorization() == .authorized else { return .unauthorized }
+      guard source.authorization().canAttemptRead else { return .unauthorized }
       do {
         return .loaded(try source.load())
+      } catch AddressBookContacts.ReadError.unavailable {
+        return .unavailable
       } catch {
         return .transientFailure
       }
@@ -157,8 +166,8 @@
         unavailable = false
       case .transientFailure:
         unavailable = !hasLastGoodCatalog
-      case .unauthorized:
-        authorizationWasAvailable = false
+      case .unauthorized, .unavailable:
+        if case .unauthorized = result { lastAuthorization = nil }
         records.removeAll(keepingCapacity: false)
         snapshots.removeAll(keepingCapacity: false)
         regionRecency.removeAll(keepingCapacity: false)
@@ -258,10 +267,12 @@
         return .authorized
       case .notDetermined:
         return .notDetermined
-      case .denied, .restricted:
+      case .denied:
         return .unavailable
+      case .restricted:
+        return .restricted
       @unknown default:
-        return .unavailable
+        return .restricted
       }
     }
 

--- a/Sources/IMsgCore/ContactResolver.swift
+++ b/Sources/IMsgCore/ContactResolver.swift
@@ -75,7 +75,7 @@ public final class ContactResolver: ContactResolving, @unchecked Sendable {
     var nextRefreshAt: TimeInterval = -.infinity
     var invalidated = true
     var refreshing = false
-    var authorizationWasAvailable = false
+    var lastAuthorization: ContactCatalogAuthorization?
     var hasLastGoodCatalog = false
     var unavailable = true
     var cancelObservation: (() -> Void)?
@@ -108,11 +108,16 @@ public final class ContactResolver: ContactResolving, @unchecked Sendable {
   ) async -> any ContactResolving {
     #if os(macOS)
       let store = CNContactStore()
+      let environment = ProcessInfo.processInfo.environment
+      let isSSH = environment["SSH_CONNECTION"] != nil || environment["SSH_CLIENT"] != nil
       let initialStatus = CNContactStore.authorizationStatus(for: .contacts)
-      if initialStatus == .notDetermined, accessPolicy == .requestIfNeeded {
+      if initialStatus == .notDetermined, accessPolicy == .requestIfNeeded, !isSSH {
         _ = await requestAccess(store: store)
       }
-      return ContactResolver(region: region, source: contactSource(store: store))
+      let nativeSource = contactSource(store: store)
+      let source =
+        isSSH ? nativeSource.allowingAddressBook(at: AddressBookContacts.directory) : nativeSource
+      return ContactResolver(region: region, source: source)
     #else
       _ = region
       _ = accessPolicy

--- a/Sources/imsg/Commands/BridgeIntroCommands.swift
+++ b/Sources/imsg/Commands/BridgeIntroCommands.swift
@@ -347,6 +347,7 @@ enum NicknameCommand {
         if contacts.contactsUnavailable {
           StdoutWriter.writeLine(
             "Check System Settings > Privacy & Security > Contacts for the app running imsg.")
+          StdoutWriter.writeLine("Over SSH, also check Full Disk Access for the SSH service.")
         }
       }
       return

--- a/Tests/IMsgCoreTests/AddressBookContactsTests.swift
+++ b/Tests/IMsgCoreTests/AddressBookContactsTests.swift
@@ -1,0 +1,224 @@
+#if os(macOS)
+  import Foundation
+  import SQLite
+  import Testing
+
+  @testable import IMsgCore
+
+  private func addressBookFixtureDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+  }
+
+  private func addressBookFixture(_ directory: URL, source: String? = nil) throws -> Connection {
+    let directory = source.map { directory.appendingPathComponent("Sources/\($0)") } ?? directory
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    let db = try Connection(directory.appendingPathComponent("AddressBook-v22.abcddb").path)
+    try db.execute(
+      """
+      CREATE TABLE ZABCDRECORD (Z_PK INTEGER PRIMARY KEY, ZNICKNAME TEXT, ZFIRSTNAME TEXT, ZLASTNAME TEXT);
+      CREATE TABLE ZABCDPHONENUMBER (ZOWNER INTEGER, ZFULLNUMBER TEXT);
+      CREATE TABLE ZABCDEMAILADDRESS (ZOWNER INTEGER, ZADDRESS TEXT);
+      """)
+    return db
+  }
+
+  private func addAddressBookContact(
+    _ db: Connection, name: String, phone: String, email: String
+  ) throws {
+    try db.run("INSERT INTO ZABCDRECORD VALUES (1, '', ?, 'Example')", name)
+    try db.run("INSERT INTO ZABCDPHONENUMBER VALUES (1, ?)", phone)
+    try db.run("INSERT INTO ZABCDEMAILADDRESS VALUES (1, ?)", email)
+  }
+
+  private func addressBookResolver(
+    _ directory: URL, authorization: ContactCatalogAuthorization = .notDetermined
+  ) -> ContactResolver {
+    let source = ContactCatalogSource(
+      authorization: { authorization },
+      load: { [ContactCatalogRecord(name: "Native", phones: ["+14155550111"], emails: [])] },
+      observeChanges: { _ in {} }
+    )
+    return ContactResolver(
+      region: "US", source: source.allowingAddressBook(at: directory), refreshInterval: 0)
+  }
+
+  @Test
+  func addressBookResolvesLocalAndAccountContactsWithSharedNormalization() throws {
+    let directory = try addressBookFixtureDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let local = try addressBookFixture(directory)
+    let account = try addressBookFixture(directory, source: "account-a")
+    try addAddressBookContact(
+      local, name: "Ada", phone: "+1 (415) 555-0111", email: "ADA@example.invalid")
+    try addAddressBookContact(
+      account, name: "Grace", phone: "+14155550222", email: "grace@example.invalid")
+    try account.run("UPDATE ZABCDRECORD SET ZNICKNAME = 'Amazing Grace'")
+    let resolver = addressBookResolver(directory)
+
+    #expect(!resolver.contactsUnavailable)
+    #expect(resolver.displayName(for: "+14155550111") == "Ada Example")
+    #expect(resolver.displayName(for: "iMessage;-;+14155550222") == "Amazing Grace")
+    #expect(resolver.displayName(for: "ada@example.invalid") == "Ada Example")
+    #expect(resolver.displayName(for: "GRACE@example.invalid") == "Amazing Grace")
+    #expect(resolver.displayName(for: "missing@example.invalid") == nil)
+    #expect(
+      resolver.searchByName("Grace") == [
+        ContactMatch(name: "Amazing Grace", handle: "+14155550222")
+      ])
+  }
+
+  @Test(arguments: [
+    ContactCatalogAuthorization.authorized, .notDetermined, .unavailable, .restricted,
+  ])
+  func addressBookFallbackPreservesNativeAndRestrictedAccess(
+    authorization: ContactCatalogAuthorization
+  ) throws {
+    let directory = try addressBookFixtureDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let db = try addressBookFixture(directory)
+    try addAddressBookContact(db, name: "Ada", phone: "+14155550111", email: "ada@example.invalid")
+    let resolver = addressBookResolver(directory, authorization: authorization)
+
+    let expected: String?
+    switch authorization {
+    case .authorized: expected = "Native"
+    case .restricted: expected = nil
+    case .addressBook, .notDetermined, .unavailable: expected = "Ada Example"
+    }
+    #expect(resolver.displayName(for: "+14155550111") == expected)
+    #expect(resolver.contactsUnavailable == (authorization == .restricted))
+  }
+
+  @Test(arguments: ["empty", "missing", "unsupported"])
+  func addressBookDistinguishesUnavailableStoresFromNoMatch(kind: String) throws {
+    let directory = try addressBookFixtureDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    if kind != "missing" {
+      let db = try addressBookFixture(directory)
+      if kind == "unsupported" { try db.execute("DROP TABLE ZABCDPHONENUMBER") }
+    }
+    let resolver = addressBookResolver(directory)
+    #expect(resolver.displayName(for: "+14155550111") == nil)
+    #expect(resolver.contactsUnavailable == (kind != "empty"))
+    if kind == "missing" {
+      #expect(
+        !FileManager.default.fileExists(
+          atPath: directory.appendingPathComponent("AddressBook-v22.abcddb").path))
+    }
+  }
+
+  @Test
+  func addressBookRefreshSeesWALUpdatesAndClearsNamesWhenStoreDisappears() throws {
+    let directory = try addressBookFixtureDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let db = try addressBookFixture(directory)
+    try db.execute("PRAGMA journal_mode = WAL")
+    try addAddressBookContact(db, name: "Ada", phone: "+14155550111", email: "ada@example.invalid")
+    let resolver = addressBookResolver(directory)
+    #expect(resolver.displayName(for: "+14155550111") == "Ada Example")
+
+    try db.execute("BEGIN IMMEDIATE")
+    try db.execute("UPDATE ZABCDRECORD SET ZNICKNAME = 'Updated'")
+    #expect(resolver.displayName(for: "+14155550111") == "Ada Example")
+    try db.execute("COMMIT")
+    #expect(resolver.displayName(for: "+14155550111") == "Updated")
+
+    try FileManager.default.removeItem(
+      at: directory.appendingPathComponent("AddressBook-v22.abcddb"))
+    #expect(resolver.displayName(for: "+14155550111") == nil)
+    #expect(resolver.contactsUnavailable)
+  }
+
+  @Test
+  func addressBookDoesNotReturnPartialCatalogForUnreadableAccount() throws {
+    let directory = try addressBookFixtureDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let db = try addressBookFixture(directory)
+    try addAddressBookContact(db, name: "Ada", phone: "+14155550111", email: "ada@example.invalid")
+    let broken = try addressBookFixture(directory, source: "account-b")
+    try broken.execute("DROP TABLE ZABCDRECORD")
+    let resolver = addressBookResolver(directory)
+    #expect(resolver.displayName(for: "+14155550111") == nil)
+    #expect(resolver.contactsUnavailable)
+  }
+
+  @Test
+  func addressBookRetainsLastCatalogWhileDatabaseIsBusy() throws {
+    let directory = try addressBookFixtureDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let db = try addressBookFixture(directory)
+    try addAddressBookContact(db, name: "Ada", phone: "+14155550111", email: "ada@example.invalid")
+    let resolver = addressBookResolver(directory)
+    #expect(resolver.displayName(for: "+14155550111") == "Ada Example")
+    try db.execute("BEGIN EXCLUSIVE")
+    defer { try? db.execute("ROLLBACK") }
+    #expect(resolver.displayName(for: "+14155550111") == "Ada Example")
+    #expect(!resolver.contactsUnavailable)
+  }
+  @Test
+  func addressBookRejectsUnreadableAccountDirectory() throws {
+    let directory = try addressBookFixtureDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let db = try addressBookFixture(directory)
+    try addAddressBookContact(db, name: "Ada", phone: "+14155550111", email: "ada@example.invalid")
+    _ = try addressBookFixture(directory, source: "denied")
+    let denied = directory.appendingPathComponent("Sources/denied")
+    try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: denied.path)
+    defer {
+      try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: denied.path)
+    }
+    let resolver = addressBookResolver(directory)
+    let name = resolver.displayName(for: "+14155550111")
+    let unavailable = resolver.contactsUnavailable
+    #expect(name == nil)
+    #expect(unavailable)
+  }
+
+  @Test
+  func addressBookRejectsRetiredStoreWhenNewerVersionExists() throws {
+    let directory = try addressBookFixtureDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let db = try addressBookFixture(directory)
+    try addAddressBookContact(db, name: "Ada", phone: "+14155550111", email: "ada@example.invalid")
+    try Data().write(to: directory.appendingPathComponent("AddressBook-v23.abcddb"))
+    let resolver = addressBookResolver(directory)
+    let name = resolver.displayName(for: "+14155550111")
+    let unavailable = resolver.contactsUnavailable
+    #expect(name == nil)
+    #expect(unavailable)
+  }
+  @Test(arguments: ["missing", "readable", "locked"])
+  func addressBookSourceChangesInvalidateCachedNativeNames(databaseState: String) throws {
+    let directory = try addressBookFixtureDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    var database: Connection?
+    if databaseState != "missing" {
+      let db = try addressBookFixture(directory)
+      try addAddressBookContact(
+        db, name: "Ada", phone: "+14155550111", email: "ada@example.invalid")
+      database = db
+    }
+    var authorization = ContactCatalogAuthorization.authorized
+    let native = ContactCatalogSource(
+      authorization: { authorization },
+      load: { [ContactCatalogRecord(name: "Native", phones: ["+14155550111"], emails: [])] },
+      observeChanges: { _ in {} }
+    )
+    let resolver = ContactResolver(
+      region: "US", source: native.allowingAddressBook(at: directory), refreshInterval: 60)
+    let before = resolver.displayName(for: "+14155550111")
+    #expect(before == "Native")
+    if databaseState == "locked" { try #require(database).execute("BEGIN EXCLUSIVE") }
+    defer { if databaseState == "locked" { try? database?.execute("ROLLBACK") } }
+    authorization = .unavailable
+    let after = resolver.displayName(for: "+14155550111")
+    let unavailable = resolver.contactsUnavailable
+    #expect(after == (databaseState == "readable" ? "Ada Example" : nil))
+    #expect(unavailable == (databaseState != "readable"))
+    authorization = .authorized
+    let restored = resolver.displayName(for: "+14155550111")
+    #expect(restored == "Native")
+  }
+#endif

--- a/Tests/IMsgCoreTests/ContactResolverTests.swift
+++ b/Tests/IMsgCoreTests/ContactResolverTests.swift
@@ -235,18 +235,26 @@ func noOpContactResolverCanRepresentUnavailableContacts() {
     #expect(resolver.contactsUnavailable == false)
   }
 
-  @Test(.timeLimit(.minutes(1)))
-  func contactCatalogCoalescesConcurrentRefreshes() {
+  @Test(.timeLimit(.minutes(1)), arguments: [false, true])
+  func contactCatalogCoalescesConcurrentRefreshes(changingSource: Bool) {
     let source = ContactSourceHarness(records: [contactRecord(name: "Alice")])
     let started = DispatchSemaphore(value: 0)
     let release = DispatchSemaphore(value: 0)
-    source.blockNextLoad(started: started, release: release)
     let resolver = ContactResolver(region: "US", source: source.source, refreshInterval: 60)
+    if changingSource {
+      _ = resolver.displayName(for: "+15551234567")
+      source.setRecords([contactRecord(name: "Bob")])
+      source.setAuthorization(.addressBook)
+    }
+    source.blockNextLoad(started: started, release: release)
+    let entered = DispatchSemaphore(value: 0)
     let group = DispatchGroup()
     let threads = (0..<8).map { _ in
       group.enter()
       return Thread {
-        _ = resolver.displayName(for: "+15551234567")
+        entered.signal()
+        let name = resolver.displayName(for: "+15551234567")
+        #expect(name == (changingSource ? "Bob" : "Alice"))
         group.leave()
       }
     }
@@ -255,10 +263,11 @@ func noOpContactResolverCanRepresentUnavailableContacts() {
     }
 
     started.wait()
-    #expect(source.loadCount == 1)
+    for _ in threads { entered.wait() }
+    #expect(source.loadCount == (changingSource ? 2 : 1))
     release.signal()
     group.wait()
-    #expect(source.loadCount == 1)
+    #expect(source.loadCount == (changingSource ? 2 : 1))
   }
 
   @Test

--- a/Tests/imsgTests/RPCFreshnessTests.swift
+++ b/Tests/imsgTests/RPCFreshnessTests.swift
@@ -125,31 +125,6 @@ func deletedWarmChatIDRejectsBeforeSendOrBridgeDispatch() async throws {
   #expect(bridgeCount == 0)
 }
 
-private final class RPCWatchStreamHarness: @unchecked Sendable {
-  private let lock = NSLock()
-  private let ready = DispatchSemaphore(value: 0)
-  private var continuation: AsyncThrowingStream<Message, Error>.Continuation?
-
-  func stream() -> AsyncThrowingStream<Message, Error> {
-    AsyncThrowingStream { continuation in
-      lock.withLock { self.continuation = continuation }
-      ready.signal()
-    }
-  }
-
-  func waitUntilReady() -> Bool {
-    ready.wait(timeout: .now() + 1) == .success
-  }
-
-  func yield(_ message: Message) {
-    lock.withLock { continuation }?.yield(message)
-  }
-
-  func finish() {
-    lock.withLock { continuation }?.finish()
-  }
-}
-
 @Test(.timeLimit(.minutes(1)))
 func rpcWatchReadsMetadataAndParticipantsForEveryEmission() async throws {
   let fixture = try makeWALFixture()
@@ -158,12 +133,12 @@ func rpcWatchReadsMetadataAndParticipantsForEveryEmission() async throws {
       at: URL(fileURLWithPath: fixture.path).deletingLastPathComponent())
   }
   let output = TestRPCOutput()
-  let stream = RPCWatchStreamHarness()
+  let (stream, continuation) = AsyncThrowingStream<Message, Error>.makeStream()
   let server = RPCServer(
     store: fixture.store,
     verbose: false,
     output: output,
-    watchStreamProvider: { _, _, _, _, _ in stream.stream() }
+    watchStreamProvider: { _, _, _, _, _ in stream }
   )
   let first = Message(
     rowID: 10,
@@ -190,8 +165,7 @@ func rpcWatchReadsMetadataAndParticipantsForEveryEmission() async throws {
 
   await server.handleLineForTesting(
     #"{"jsonrpc":"2.0","id":"watch","method":"watch.subscribe","params":{}}"#)
-  #expect(stream.waitUntilReady())
-  stream.yield(first)
+  continuation.yield(first)
   await output.waitForOutputCount(2)
 
   try fixture.writer.run(
@@ -202,8 +176,8 @@ func rpcWatchReadsMetadataAndParticipantsForEveryEmission() async throws {
   try fixture.writer.run("INSERT INTO handle(ROWID, id) VALUES (2, '+999')")
   try fixture.writer.run("DELETE FROM chat_handle_join WHERE chat_id = 1")
   try fixture.writer.run("INSERT INTO chat_handle_join(chat_id, handle_id) VALUES (1, 2)")
-  stream.yield(second)
-  stream.finish()
+  continuation.yield(second)
+  continuation.finish()
   await output.waitForOutputCount(3)
   await server.subscriptions.waitUntilEmpty()
 

--- a/docs/chats.md
+++ b/docs/chats.md
@@ -20,6 +20,7 @@ display name or raw chat identifier.
 Empty and missing Messages display names fall back to the raw chat identifier,
 including when Contacts is unavailable over SSH. JSON exposes a resolved Contacts
 match separately as `contact_name` in both `chats` and RPC `chats.list`.
+[Contacts over SSH](permissions.md#contacts-over-ssh) can resolve these names with Full Disk Access even when Contacts.framework has no grant.
 The presentation fallback belongs to `name`: an empty stored title remains empty
 in JSON `display_name` and chat-detail metadata.
 
@@ -43,7 +44,7 @@ Objects returned by `imsg chats --json` and JSON-RPC `chats.list` include:
 | `id` | int | `chat.ROWID`. Stable within one Messages database. Preferred routing handle. |
 | `name` | string | Messages display name or raw chat identifier fallback. |
 | `display_name` | string | Chat title metadata. An empty stored title remains empty. |
-| `contact_name` | string | Resolved Contacts name when permission granted. |
+| `contact_name` | string | Resolved name from Contacts.framework or the readable AddressBook store over SSH. |
 | `identifier` | string | `chat.chat_identifier` — Messages' portable handle. |
 | `guid` | string | `chat.guid` — Messages' portable GUID. |
 | `service` | string | `iMessage`, `SMS`, etc. |

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -55,13 +55,28 @@ Grant it under **System Settings → Privacy & Security → Contacts**.
 `imsg nickname --local` distinguishes `(Contacts unavailable)` from `(none)` in
 text output; JSON exposes the same distinction as `contacts_unavailable`. An
 unavailable result means imsg could not read Contacts, not that the handle has no
-matching contact. For SSH and other indirect launches, check the Contacts grant
-for the app or process running imsg. Full Disk Access alone does not grant Contacts
-access.
+matching contact. For indirect launches, check the grant for the app or process
+running imsg. Full Disk Access does not grant access through Contacts.framework;
+SSH sessions can use the read-only database path described below.
 
-If you skip this, JSON output simply leaves the resolved name fields empty. Nothing else changes. A long-running `imsg rpc` child observes Contacts changes and periodically rechecks authorization, so grants and contact edits become visible without restarting. Revocation clears cached names; a transient Contacts read failure retains the last successful catalog until the next refresh.
+When neither Contacts source is readable, JSON output leaves resolved name fields empty. A long-running `imsg rpc` child observes Contacts changes and periodically rechecks authorization, so grants and contact edits become visible without restarting. Revocation clears cached names; a transient Contacts read failure retains the last successful catalog until the next refresh.
 
 On Macs with CardDAV accounts such as Google or Yahoo, Apple's Contacts framework may periodically write `Could not fetch group … :ABGroup` reconciliation messages to stderr. These messages are benign and do not come from `imsg`; a parent process that captures `imsg rpc --json` stderr should not report this specific framework message as an `imsg` error.
+
+## Contacts over SSH
+
+SSH sessions prefer Contacts.framework when its permission is available. Otherwise, imsg automatically reads the local AddressBook SQLite stores using the SSH service's existing Full Disk Access. This applies to phone/email lookup, `nickname --local`, chat and message name fields, and `imsg rpc`. It requires no SIP change or separate Contacts prompt, including when SSH allocates a TTY.
+
+```bash
+ssh your-mac 'imsg nickname --local --address friend@example.com --json'
+ssh your-mac 'imsg chats --limit 10 --json'
+```
+
+Give the SSH service Full Disk Access on the Mac, then reconnect. Depending on the macOS version, the relevant control is [**System Settings → General → Sharing → Remote Login → Allow full disk access for remote users**](https://support.apple.com/guide/mac-help/mchlp1066/mac), or the SSH service's Full Disk Access entry. A Contacts restriction imposed by the system remains unavailable.
+
+The contact data must already be synced to that Mac. The reader supports `AddressBook-v22.abcddb` in `~/Library/Application Support/AddressBook/` and its account `Sources` directories. A newer unsupported database version is reported as unavailable instead of reading a retired older copy. It opens existing databases read-only and includes WAL updates; it never edits Contacts, changes permission grants, or copies the database elsewhere. Outside SSH (detected through `SSH_CONNECTION` or `SSH_CLIENT`), Contacts.framework remains the only source.
+
+Long-running processes refresh the database catalog every 30 seconds on use, or sooner after a Contacts change notification. Changes to Contacts authorization re-evaluate the source immediately before returning cached names. Missing access, a removed database, or an unsupported schema clears cached names on that refresh and reports Contacts unavailable. A transient SQLite lock retains the last successful catalog. An empty, readable store is a valid no-match result, so check that Contacts has finished syncing before diagnosing permissions.
 
 ## Why these grants live in three different places
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -109,9 +109,9 @@ If `which imsg` doesn't point at the Homebrew prefix, remove the older binary or
 
 ## Contacts names are missing in JSON output
 
-Contacts permission isn't granted, or the contact isn't matched.
+The Contacts source is unavailable, the Mac has not synced the contact, or the handle has no match.
 
-1. Confirm under **System Settings → Privacy & Security → Contacts** that the terminal/wrapper app is enabled.
+1. Confirm under **System Settings → Privacy & Security → Contacts** that the terminal/wrapper app is enabled. Over SSH, imsg can instead use the read-only AddressBook store when the SSH service has Full Disk Access; see [Contacts over SSH](permissions.md#contacts-over-ssh). `imsg nickname --local --address <handle> --json` distinguishes unavailable access from no match with `contacts_unavailable`.
 2. Raw handles are always preserved in `sender`, `chat_identifier`, etc. The optional `contact_name` / `sender_name` fields are simply omitted when no match is found.
 
 If you want partial fallback names (initials, or formatted handles), do that in your consumer — `imsg` doesn't synthesize names that aren't in your Address Book.


### PR DESCRIPTION
Fixes #250.

SSH can read the Mac's AddressBook database with Full Disk Access while Contacts.framework has no grant. That left known phone numbers and email addresses unresolved, even after the earlier diagnostic and headless-prompt fixes. This implements the maintainer-approved SSH support in the shared Contacts resolver.

SSH sessions now prefer Contacts.framework when authorized and otherwise read the existing v22 AddressBook stores in SQLite read-only mode, including account stores and WAL updates. No database is copied, changed, or created; no Contacts prompt is requested over SSH, including a TTY session. Outside SSH, the native Contacts path remains the only source. System-restricted access remains unavailable.

The catalog tracks its active source. Permission/source changes discard cached data before loading the replacement, including when that replacement is busy. Concurrent readers share the refresh. Missing access, unreadable account directories, absent/unsupported stores, and newer database versions cannot become partial success or stale-name results. Transient locking preserves a catalog only from the same source.

Validation:
- Signed CLI on macOS 27 over real SSH: known phone and email lookups changed from `found: false, contacts_unavailable: true` to `found: true, contacts_unavailable: false`, with names matched against the local database without publishing contact details.
- `chats` and RPC `chats.list` resolve the same nonzero set of contact names; RPC initialization reports Contacts available. An SSH TTY lookup completes without a prompt. The same binary outside SSH retains native-only permission behavior.
- Real SQLite fixtures cover normalization, local/account stores, native preference, restricted access, empty/missing/unsupported stores, WAL visibility, access loss, locks, and source changes.
- Red/green cases reproduced denied-directory skipping, stale version selection, source-transition caching, and the review finding where a locked replacement source retained native names.
- Full tests, lint, universal build, Codex autoreview, and exact-head CI are recorded in the follow-up.

README, permissions, chat-list, and troubleshooting docs describe setup and supported storage. The SSH process still needs Full Disk Access and contact data synced to that Mac. This reads the supported private v22 schema; an unknown newer version reports unavailable rather than using a retired copy.

Thanks to @riverr4t for the report. No changelog is changed before release.

Final local validation: `make test` passes 727 Swift tests plus native helper and docs-site tests; `make lint` retains the existing 16 non-serious warnings; `make build` produces the universal CLI and helper. Codex autoreview has no actionable P0–P2 findings after the cache-transition repair. One earlier local full-suite attempt stalled and was stopped; the final standard rerun passed.

CI follow-up: the first macOS run exposed the existing `rpcWatchReadsMetadataAndParticipantsForEveryEmission` fixture waiting only one second for stream readiness, then continuing after that expectation failed. It could drop the first message and wait forever. Replaced the semaphore/optional-continuation harness with a pre-created buffered stream, retaining both real WAL metadata assertions and removing 26 net test-support lines. Ten full diagnostic stress runs completed; the final standard suite also passes. No production behavior or timeout was changed for this repair.
