### PR TITLE
chore(deps): update GitHub Pages deployment action

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -51,4 +51,4 @@ jobs:
 
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Dependencies
 
 - Update PhoneNumberKit to 5.0.8 for current phone-number metadata (#251).
+- Update the GitHub Pages deployment action to 5.0.1 for deployment-status polling backoff and jitter.
 
 ### Maintenance
 


### PR DESCRIPTION
Update the pinned GitHub Pages deployment action from 5.0.0 to 5.0.1, which adds bounded backoff and jitter while polling deployment status. Its inputs, Node runtime, and deployment permissions are unchanged. Keep the Unreleased dependency notes current.

Dependency audit on 2026-09-03:

| Dependency | Current version | Result |
| --- | --- | --- |
| Commander | 0.2.4 | Latest stable; SwiftPM resolution unchanged |
| SQLite.swift | 0.16.0 | Latest stable; SwiftPM resolution unchanged |
| PhoneNumberKit | 5.0.8 | Latest stable; SwiftPM resolution unchanged |
| Swift Linux image | 6.3.3-noble | Latest stable Swift release |
| SwiftLint | 0.65.1 | Latest stable |
| Node | 26 | Tracks the current Node 26 release |
| actions/checkout | 7.0.1 / v7 | Current; immutable Pages pin matches the tag |
| actions/setup-node | 7.0.0 | Current; immutable pin matches the tag |
| actions/configure-pages | 6.0.0 | Current; immutable pin matches the tag |
| actions/upload-pages-artifact | 5.0.0 | Current; immutable pin matches the tag |
| actions/deploy-pages | 5.0.0 → 5.0.1 | Updated to verified commit 368f82528645a54fb793d4d04e342629a3f51346 |
| actions/create-github-app-token | 3.2.0 | Current; both immutable pins match the tag |

The shared release workflow intentionally remains pinned to `6ecd9e56984238f6bab55eb5504a64fbf867e260`. Comparing it with current upstream main (`6906c82d483aba1b8084b22cfd5b99d334b10160`) shows that main lacks the Linux Bash shell, compatible PKCS#12 import, signing-keychain selection, and tag-checkout fixes used by imsg's successful releases. Moving the pin would regress that contract. The existing upstream follow-ups are [release-workflows#24](https://github.com/openclaw/release-workflows/pull/24) for the release repairs and [#26](https://github.com/openclaw/release-workflows/pull/26) for its own dependency refresh. Revisit the caller pin after those changes are integrated and validated; this PR does not replace working release code with an unmerged integration.

Validation:
- `swift package update`: everything already up to date; manifest and lockfile unchanged.
- Checked upstream release metadata, immutable action SHAs, and the deploy-pages source/action contract diff.
- `actionlint .github/workflows/*.yml`: passes.
- `node --test scripts/build-docs-site.test.mjs`: 2 tests pass.
- `make docs-site`: passes.
- `git diff --check`: passes.

The normal macOS/Linux CI and the post-merge Pages deployment provide hosted verification. No application release or tag is requested.
