### PR TITLE
fix: reject unsafe sticker inputs before dispatch

### DIFF
--- a/Sources/IMsgCore/SecurePath.swift
+++ b/Sources/IMsgCore/SecurePath.swift
@@ -6,17 +6,8 @@ import Foundation
   import Glibc
 #endif
 
-/// Lexical-walk symlink detector. Used wherever we accept a filesystem path
-/// from outside the dylib (RPC inbox dir, attachment paths) and want to refuse
-/// any path that traverses a symbolic link, including parent components.
-///
-/// `realpath()` alone isn't sufficient: a same-UID attacker who can write to
-/// our RPC inbox could otherwise symlink an arbitrary file (a credential file,
-/// a password manager DB) into a location they control and have Messages.app
-/// exfiltrate it as an attachment. Comparing the resolved path against the
-/// lexical input is fragile too — macOS rewrites `/tmp` to `/private/tmp`,
-/// breaking that check for legitimate paths. Walking each component with
-/// `lstat()` and refusing the path on any `S_IFLNK` is the robust answer.
+/// Preserves lexical path components so symlinks cannot disappear through `..`
+/// normalization. Only macOS's trusted system aliases are expanded.
 public enum SecurePath {
   private static func normalizingTrustedSystemAliasPrefix(_ path: String) -> String {
     let aliases = [

--- a/Sources/IMsgCore/StickerAsset.swift
+++ b/Sources/IMsgCore/StickerAsset.swift
@@ -128,25 +128,8 @@ public enum StickerAssetPreparer {
       let extensionName: String
     }
 
-    private static func normalizedLexicalPath(_ path: String) -> String {
-      var result = (path as NSString).expandingTildeInPath
-      if !result.hasPrefix("/") {
-        result = (FileManager.default.currentDirectoryPath as NSString)
-          .appendingPathComponent(result)
-      }
-      result = (result as NSString).standardizingPath
-      if result == "/tmp" || result.hasPrefix("/tmp/") {
-        result = "/private/tmp" + result.dropFirst(4)
-      } else if result == "/var" || result.hasPrefix("/var/") {
-        result = "/private/var" + result.dropFirst(4)
-      } else if result == "/etc" || result.hasPrefix("/etc/") {
-        result = "/private/etc" + result.dropFirst(4)
-      }
-      return result
-    }
-
     private static func securelyOpenDirectory(_ path: String) throws -> (fd: Int32, path: String) {
-      let normalized = normalizedLexicalPath(path)
+      let normalized = SecurePath.absoluteLexicalPath(path)
       let components = (normalized as NSString).pathComponents.filter { $0 != "/" }
       var directoryFD = Darwin.open("/", O_RDONLY | O_CLOEXEC | O_DIRECTORY)
       guard directoryFD >= 0 else { throw StickerAssetError.notRegularFile(normalized) }
@@ -167,21 +150,22 @@ public enum StickerAssetPreparer {
     }
 
     private static func securelyOpenForReading(_ path: String) throws -> (fd: Int32, path: String) {
-      let normalized = normalizedLexicalPath(path)
+      let normalized = SecurePath.absoluteLexicalPath(path)
       let leaf = (normalized as NSString).lastPathComponent
       guard !leaf.isEmpty else { throw StickerAssetError.notRegularFile(normalized) }
       let parentPath = (normalized as NSString).deletingLastPathComponent
       let parent = try securelyOpenDirectory(parentPath)
       let directoryFD = parent.fd
-      let fileFD = Darwin.openat(directoryFD, leaf, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+      // Inspect the opened descriptor before reading; a FIFO must not wait for a writer.
+      let fileFD = Darwin.openat(directoryFD, leaf, O_RDONLY | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW)
       Darwin.close(directoryFD)
       guard fileFD >= 0 else { throw StickerAssetError.notRegularFile(normalized) }
       return (fileFD, normalized)
     }
 
     private static func discardStagedFile(at path: String, trustedRoot: String) {
-      let normalized = normalizedLexicalPath(path)
-      let normalizedRoot = normalizedLexicalPath(trustedRoot)
+      let normalized = SecurePath.absoluteLexicalPath(path)
+      let normalizedRoot = SecurePath.absoluteLexicalPath(trustedRoot)
       guard normalized.hasPrefix(normalizedRoot + "/") else { return }
       let directoryPath = (normalized as NSString).deletingLastPathComponent
       let filename = (normalized as NSString).lastPathComponent
@@ -246,7 +230,7 @@ public enum StickerAssetPreparer {
       root: URL,
       filename: String
     ) throws -> URL {
-      let normalizedRoot = normalizedLexicalPath(root.path)
+      let normalizedRoot = SecurePath.absoluteLexicalPath(root.path)
       guard !SecurePath.hasSymlinkComponent(normalizedRoot) else {
         throw StickerAssetError.symlink(normalizedRoot)
       }
@@ -256,17 +240,7 @@ public enum StickerAssetPreparer {
         withIntermediateDirectories: true,
         attributes: [.posixPermissions: 0o700]
       )
-      guard !SecurePath.hasSymlinkComponent(normalizedRoot) else {
-        throw StickerAssetError.symlink(normalizedRoot)
-      }
-
-      let rootFD = Darwin.open(
-        normalizedRoot,
-        O_RDONLY | O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW
-      )
-      guard rootFD >= 0 else {
-        throw StickerAssetError.couldNotStage("could not open destination directory")
-      }
+      let rootFD = try securelyOpenDirectory(normalizedRoot).fd
       defer { Darwin.close(rootFD) }
 
       let directoryName = UUID().uuidString

--- a/Tests/IMsgCoreTests/StickerAssetTests.swift
+++ b/Tests/IMsgCoreTests/StickerAssetTests.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import Darwin
 import Foundation
 import ImageIO
 import Testing
@@ -72,6 +73,10 @@ func stickerPreparationRejectsUnsafeOrInvalidInputs() throws {
   #expect(throws: StickerAssetError.self) {
     try StickerAssetPreparer.prepare(at: linkedChild.path, destinationRoot: staged)
   }
+  #expect(throws: StickerAssetError.self) {
+    try StickerAssetPreparer.prepare(
+      at: parentLink.path + "/../valid.png", destinationRoot: staged)
+  }
 
   let corrupt = root.appendingPathComponent("corrupt.png")
   try Data("not an image".utf8).write(to: corrupt)
@@ -106,6 +111,32 @@ func stickerPreparationRejectsUnsafeOrInvalidInputs() throws {
   #expect(throws: StickerAssetError.self) {
     try StickerAssetPreparer.prepare(at: root.path, destinationRoot: staged)
   }
+}
+
+@Test
+func stickerPreparationRejectsFIFOWithoutWaitingForAWriter() throws {
+  let root = FileManager.default.temporaryDirectory
+    .appendingPathComponent(UUID().uuidString, isDirectory: true)
+  try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+  defer { try? FileManager.default.removeItem(at: root) }
+  let fifo = root.appendingPathComponent("sticker.png")
+  #expect(mkfifo(fifo.path, 0o600) == 0)
+
+  let completed = DispatchSemaphore(value: 0)
+  DispatchQueue.global().async {
+    defer { completed.signal() }
+    #expect(throws: StickerAssetError.self) {
+      try StickerAssetPreparer.prepare(at: fifo.path)
+    }
+  }
+  let rejectedWithoutWriter = completed.wait(timeout: .now() + 2) == .success
+  // Release a regressed blocking open before removing the fixture or ending the test.
+  if !rejectedWithoutWriter {
+    let writer = open(fifo.path, O_WRONLY | O_NONBLOCK)
+    if writer >= 0 { close(writer) }
+    #expect(completed.wait(timeout: .now() + 2) == .success)
+  }
+  #expect(rejectedWithoutWriter)
 }
 
 @Test

--- a/Tests/IMsgCoreTests/StickerAssetTests.swift
+++ b/Tests/IMsgCoreTests/StickerAssetTests.swift
@@ -1,5 +1,4 @@
 import CoreGraphics
-import Darwin
 import Foundation
 import ImageIO
 import Testing
@@ -111,32 +110,6 @@ func stickerPreparationRejectsUnsafeOrInvalidInputs() throws {
   #expect(throws: StickerAssetError.self) {
     try StickerAssetPreparer.prepare(at: root.path, destinationRoot: staged)
   }
-}
-
-@Test
-func stickerPreparationRejectsFIFOWithoutWaitingForAWriter() throws {
-  let root = FileManager.default.temporaryDirectory
-    .appendingPathComponent(UUID().uuidString, isDirectory: true)
-  try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-  defer { try? FileManager.default.removeItem(at: root) }
-  let fifo = root.appendingPathComponent("sticker.png")
-  #expect(mkfifo(fifo.path, 0o600) == 0)
-
-  let completed = DispatchSemaphore(value: 0)
-  DispatchQueue.global().async {
-    defer { completed.signal() }
-    #expect(throws: StickerAssetError.self) {
-      try StickerAssetPreparer.prepare(at: fifo.path)
-    }
-  }
-  let rejectedWithoutWriter = completed.wait(timeout: .now() + 2) == .success
-  // Release a regressed blocking open before removing the fixture or ending the test.
-  if !rejectedWithoutWriter {
-    let writer = open(fifo.path, O_WRONLY | O_NONBLOCK)
-    if writer >= 0 { close(writer) }
-    #expect(completed.wait(timeout: .now() + 2) == .success)
-  }
-  #expect(rejectedWithoutWriter)
 }
 
 @Test

--- a/Tests/imsgTests/CommandRouterTests.swift
+++ b/Tests/imsgTests/CommandRouterTests.swift
@@ -1,4 +1,6 @@
+import Darwin
 import Foundation
+import IMsgCore
 import Testing
 
 @testable import imsg
@@ -45,6 +47,22 @@ func executableWrapperPropagatesRouterStatus() throws {
 }
 
 @Test
+func stickerCommandRejectsFIFOWithoutWaitingForAWriter() throws {
+  let root = FileManager.default.temporaryDirectory
+    .appendingPathComponent(UUID().uuidString, isDirectory: true)
+  try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+  defer { try? FileManager.default.removeItem(at: root) }
+  let fifo = root.appendingPathComponent("sticker.png")
+  #expect(mkfifo(fifo.path, 0o600) == 0)
+
+  let result = try runIMsgProcess([
+    "send-sticker", "--chat", "iMessage;-;+15550000000", "--file", fifo.path,
+  ])
+  #expect(result.status == 1)
+  #expect(result.output.contains("sticker must be a regular file"))
+}
+
+@Test
 func commandRouterIncludesGroupCommand() {
   let router = CommandRouter()
   #expect(router.specs.contains { $0.name == "group" })
@@ -70,8 +88,8 @@ private func runIMsgProcess(
   process.standardError = output
   try process.run()
   output.fileHandleForWriting.closeFile()
+  #expect(!ProcessTimeout.waitUntilExit(process, timeout: 3))
   let data = output.fileHandleForReading.readDataToEndOfFile()
-  process.waitUntilExit()
   return (process.terminationStatus, String(data: data, encoding: .utf8) ?? "")
 }
 

--- a/docs/advanced-imcore.md
+++ b/docs/advanced-imcore.md
@@ -153,7 +153,9 @@ cannot preserve the private audio-message flag.
 
 `send-sticker` is always bridge-only and iMessage-only. It accepts PNG/APNG,
 GIF, and JPEG images up to 500 KiB, 618x618 pixels, 100 frames, and 25 million
-total decoded pixels. It reads every frame without following symlinks and
+total decoded pixels. Inputs must be regular files; pipes, devices, and paths
+through symlinks (including `link/../image.png`) are rejected before sending.
+It reads every frame without following symlinks and
 stages a private snapshot under Messages' attachments directory. Content
 bytes—not the filename—define sticker identity. `--attach-to`
 optionally associates the sticker with an exact bubble part; `--target-part`


### PR DESCRIPTION
Sticker preparation could hang before bridge dispatch when given a FIFO. It also standardized paths before checking their components, so `link/../image.png` could bypass the documented symlink rejection.

Reuse the shared lexical-path normalization, reject non-regular inputs after a nonblocking open, and open the staging directory through the existing descriptor walk. This removes the duplicate normalizer and a redundant staging check while preserving image validation, private snapshots, and cleanup. Production code shrinks by 35 lines; regression coverage adds 22 lines.

Validation:
- Both regressions failed against the pre-fix code: the symlink traversal was accepted and the FIFO required a writer to unblock it.
- The built CLI now rejects a synthetic FIFO before bridge dispatch. No messages were sent.
- Focused sticker, shared-path, and regular-attachment tests passed.
- `make test`: 728 Swift tests, native helper tests, and docs tests passed.
- `make lint`: passed with the existing 16 warnings and no serious violations.
- Codex autoreview: no actionable P0–P2 findings.

The initial hosted run exposed queue starvation in the FIFO test. The final regression runs the actual CLI in a bounded subprocess instead; the full local suite passed again with that correction.
