### PR TITLE
fix: reject invalid CLI selectors before side effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ For SMS, enable Text Message Forwarding on the paired iPhone. `imsg send` uses M
 
 `--json` emits one JSON object per line. Human progress and warnings stay on stderr, so stdout remains safe to stream. Pipe finite commands through `jq -s` when you want one array.
 
+Numeric selectors are validated before work starts: chat IDs, limits, and poll option indices must be positive integers; message-part indices can also be zero. Malformed or overflowing values produce an error instead of selecting a default target. Defaults apply only when an option is omitted.
+
 ```bash
 imsg chats --json | jq -s
 imsg rpc

--- a/Sources/IMsgCore/TypingIndicator.swift
+++ b/Sources/IMsgCore/TypingIndicator.swift
@@ -133,6 +133,12 @@ import Foundation
       stopTyping: (String) throws -> Void,
       sleep: (UInt64) async throws -> Void
     ) async throws {
+      guard duration >= 0,
+        let nanoseconds = UInt64(exactly: (duration * 1_000_000_000).rounded(.towardZero))
+      else {
+        throw IMsgError.typingIndicatorFailed(
+          "Duration must be a finite, non-negative interval representable in nanoseconds")
+      }
       try startTyping(chatIdentifier)
       var stopped = false
       defer {
@@ -140,7 +146,7 @@ import Foundation
           try? stopTyping(chatIdentifier)
         }
       }
-      try await sleep(UInt64(duration * 1_000_000_000))
+      try await sleep(nanoseconds)
       try stopTyping(chatIdentifier)
       stopped = true
     }

--- a/Sources/imsg/CommandRouter.swift
+++ b/Sources/imsg/CommandRouter.swift
@@ -66,11 +66,12 @@ struct CommandRouter {
 
   func run(argv: [String]) async -> Int32 {
     let argv = normalizeArguments(argv)
-    if argv.contains("--version") || argv.contains("-V") {
+    let options = argv.prefix { $0 != "--" }
+    if options.contains("--version") || options.contains("-V") {
       StdoutWriter.writeLine(version)
       return 0
     }
-    if argv.count <= 1 || argv.contains("--help") || argv.contains("-h") {
+    if argv.count <= 1 || options.contains("--help") || options.contains("-h") {
       printHelp(for: argv)
       return 0
     }

--- a/Sources/imsg/Commands/BridgeIntroCommands.swift
+++ b/Sources/imsg/Commands/BridgeIntroCommands.swift
@@ -48,7 +48,7 @@ enum SearchCommand {
       throw ParsedValuesError.invalidOption("match")
     }
     let dbPath = values.option("db") ?? MessageStore.defaultPath
-    let limit = values.optionInt("limit") ?? 50
+    let limit = try values.optionInt("limit", minimum: 1) ?? 50
     let store = try MessageStore(path: dbPath)
     let messages = try store.searchMessages(query: q, match: match, limit: limit)
     let contacts = await contactResolverFactory()

--- a/Sources/imsg/Commands/BridgeMessagingCommands.swift
+++ b/Sources/imsg/Commands/BridgeMessagingCommands.swift
@@ -167,6 +167,7 @@ enum SendRichCommand {
     guard let chat = values.option("chat"), !chat.isEmpty else {
       throw ParsedValuesError.missingOption("chat")
     }
+    let part = try values.optionInt("part", minimum: 0) ?? 0
     let text = values.option("text") ?? ""
     let file = values.option("file") ?? ""
     let richLinkURL = values.option("url")
@@ -191,7 +192,7 @@ enum SendRichCommand {
     var params: [String: Any] = [
       "chatGuid": chat,
       "message": effectiveText,
-      "partIndex": preparedRichLink == nil ? Int(values.option("part") ?? "0") ?? 0 : 0,
+      "partIndex": preparedRichLink == nil ? part : 0,
       "ddScan": preparedRichLink == nil ? !values.flag("noDDScan") : true,
     ]
     if let preparedRichLink {
@@ -381,7 +382,7 @@ enum BridgeReactCommand {
       "chatGuid": chat,
       "selectedMessageGuid": message,
       "reactionType": prefixed,
-      "partIndex": Int(values.option("part") ?? "0") ?? 0,
+      "partIndex": try values.optionInt("part", minimum: 0) ?? 0,
     ]
     _ = try await BridgeOutput.invokeAndEmit(
       action: .sendReaction, params: params, runtime: runtime
@@ -430,7 +431,7 @@ enum EditCommand {
       "messageGuid": message,
       "editedMessage": newText,
       "backwardsCompatibilityMessage": values.option("bcText") ?? newText,
-      "partIndex": Int(values.option("part") ?? "0") ?? 0,
+      "partIndex": try values.optionInt("part", minimum: 0) ?? 0,
     ]
     _ = try await BridgeOutput.invokeAndEmit(
       action: .editMessage, params: params, runtime: runtime
@@ -469,7 +470,7 @@ enum UnsendCommand {
     let params: [String: Any] = [
       "chatGuid": chat,
       "messageGuid": message,
-      "partIndex": Int(values.option("part") ?? "0") ?? 0,
+      "partIndex": try values.optionInt("part", minimum: 0) ?? 0,
     ]
     _ = try await BridgeOutput.invokeAndEmit(
       action: .unsendMessage, params: params, runtime: runtime

--- a/Sources/imsg/Commands/ChatBackgroundCommand.swift
+++ b/Sources/imsg/Commands/ChatBackgroundCommand.swift
@@ -33,9 +33,8 @@ enum ChatBackgroundCommand {
     guard values.argument(0) == "status" else {
       throw ParsedValuesError.invalidOption("action")
     }
-    let rawChatID = try values.optionRequired("chatID")
-    guard let chatID = Int64(rawChatID), chatID > 0 else {
-      throw ParsedValuesError.invalidOption("chat-id")
+    guard let chatID = try values.optionChatID() else {
+      throw ParsedValuesError.missingOption("chat-id")
     }
 
     let dbPath = values.option("db") ?? MessageStore.defaultPath

--- a/Sources/imsg/Commands/ChatsCommand.swift
+++ b/Sources/imsg/Commands/ChatsCommand.swift
@@ -36,7 +36,7 @@ enum ChatsCommand {
     }
   ) async throws {
     let dbPath = values.option("db") ?? MessageStore.defaultPath
-    let limit = values.optionInt("limit") ?? 20
+    let limit = try values.optionInt("limit", minimum: 1) ?? 20
     let unreadOnly = values.flag("unread-only")
     let store = try MessageStore(path: dbPath)
     let chats = try store.listChats(limit: limit, unreadOnly: unreadOnly)

--- a/Sources/imsg/Commands/GroupCommand.swift
+++ b/Sources/imsg/Commands/GroupCommand.swift
@@ -20,7 +20,7 @@ enum GroupCommand {
       "imsg group --chat-id 1 --json",
     ]
   ) { values, runtime in
-    guard let chatID = values.optionInt64("chatID") else {
+    guard let chatID = try values.optionChatID() else {
       throw ParsedValuesError.missingOption("chat-id")
     }
     let dbPath = values.option("db") ?? MessageStore.defaultPath

--- a/Sources/imsg/Commands/HistoryCommand.swift
+++ b/Sources/imsg/Commands/HistoryCommand.swift
@@ -44,11 +44,11 @@ enum HistoryCommand {
       await ContactResolver.create(accessPolicy: .skipIfNotDetermined)
     }
   ) async throws {
-    guard let chatID = values.optionInt64("chatID") else {
+    guard let chatID = try values.optionChatID() else {
       throw ParsedValuesError.missingOption("chat-id")
     }
     let dbPath = values.option("db") ?? MessageStore.defaultPath
-    let limit = values.optionInt("limit") ?? 50
+    let limit = try values.optionInt("limit", minimum: 1) ?? 50
     let showAttachments = values.flag("attachments")
     let attachmentOptions = AttachmentQueryOptions(
       convertUnsupported: values.flag("convertAttachments"))

--- a/Sources/imsg/Commands/PollCommand.swift
+++ b/Sources/imsg/Commands/PollCommand.swift
@@ -267,7 +267,7 @@ enum PollCommand {
   /// Resolve exactly one option selector against the poll's stable options.
   private static func validateOptionSelector(_ values: ParsedValues) throws {
     let directID = values.option("optionID")?.trimmingCharacters(in: .whitespacesAndNewlines)
-    let indexValue = values.optionInt64("optionIndex")
+    let indexValue = try values.optionInt64("optionIndex", name: "option-index", minimum: 1)
     let textValue = values.option("option")?.trimmingCharacters(in: .whitespacesAndNewlines)
     let selectors = [directID?.isEmpty == false, indexValue != nil, textValue?.isEmpty == false]
     guard selectors.contains(true) else {
@@ -285,7 +285,7 @@ enum PollCommand {
     store: MessageStore
   ) throws -> (id: String, text: String?) {
     let directID = values.option("optionID")?.trimmingCharacters(in: .whitespacesAndNewlines)
-    let indexValue = values.optionInt64("optionIndex")
+    let indexValue = try values.optionInt64("optionIndex", name: "option-index", minimum: 1)
     let textValue = values.option("option")?.trimmingCharacters(in: .whitespacesAndNewlines)
     try validateOptionSelector(values)
     let options = try store.pollOptions(guid: pollGuid)
@@ -324,7 +324,7 @@ enum PollCommand {
     storeFactory: (String) throws -> MessageStore
   ) throws -> String {
     let chatValue = values.option("chat")?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-    let chatID = values.optionInt64("chatID") ?? Int64(chatValue)
+    let chatID = try values.optionChatID() ?? Int64(chatValue)
     if let chatID {
       let dbPath = values.option("db") ?? MessageStore.defaultPath
       let store = try storeFactory(dbPath)

--- a/Sources/imsg/Commands/ReactCommand.swift
+++ b/Sources/imsg/Commands/ReactCommand.swift
@@ -47,7 +47,7 @@ enum ReactCommand {
       try runAppleScript(source, arguments: arguments)
     }
   ) async throws {
-    guard let chatID = values.optionInt64("chatID") else {
+    guard let chatID = try values.optionChatID() else {
       throw ParsedValuesError.missingOption("chat-id")
     }
     guard let reactionString = values.option("reaction") else {

--- a/Sources/imsg/Commands/ReadCommand.swift
+++ b/Sources/imsg/Commands/ReadCommand.swift
@@ -46,7 +46,7 @@ enum ReadCommand {
     let dbPath = values.option("db") ?? MessageStore.defaultPath
     let input = ChatTargetInput(
       recipient: values.option("to") ?? "",
-      chatID: values.optionInt64("chatID"),
+      chatID: try values.optionChatID(),
       chatIdentifier: values.option("chatIdentifier") ?? "",
       chatGUID: values.option("chatGUID") ?? ""
     )

--- a/Sources/imsg/Commands/ScheduledCommand.swift
+++ b/Sources/imsg/Commands/ScheduledCommand.swift
@@ -43,15 +43,7 @@ enum ScheduledCommand {
     storeFactory: (String) throws -> MessageStore
   ) throws {
     let dbPath = values.option("db") ?? MessageStore.defaultPath
-    let limit: Int
-    if let rawLimit = values.option("limit") {
-      guard let parsed = Int(rawLimit), parsed > 0 else {
-        throw ParsedValuesError.invalidOption("limit")
-      }
-      limit = parsed
-    } else {
-      limit = 50
-    }
+    let limit = try values.optionInt("limit", minimum: 1) ?? 50
     let messages = try storeFactory(dbPath).scheduledMessages(limit: limit)
     if runtime.jsonOutput {
       for message in messages {

--- a/Sources/imsg/Commands/SendCommand.swift
+++ b/Sources/imsg/Commands/SendCommand.swift
@@ -64,7 +64,7 @@ enum SendCommand {
     let rawRecipient = values.option("to") ?? ""
     let rawInput = ChatTargetInput(
       recipient: rawRecipient,
-      chatID: values.optionInt64("chatID"),
+      chatID: try values.optionChatID(),
       chatIdentifier: values.option("chatIdentifier") ?? "",
       chatGUID: values.option("chatGUID") ?? ""
     )

--- a/Sources/imsg/Commands/StatsCommand.swift
+++ b/Sources/imsg/Commands/StatsCommand.swift
@@ -31,15 +31,7 @@ enum StatsCommand {
 
   static func run(values: ParsedValues, runtime: RuntimeOptions) async throws {
     let dbPath = values.option("db") ?? MessageStore.defaultPath
-    let chatID: Int64?
-    if let rawChatID = values.option("chatID") {
-      guard let parsed = Int64(rawChatID) else {
-        throw ParsedValuesError.invalidOption("chat-id")
-      }
-      chatID = parsed
-    } else {
-      chatID = nil
-    }
+    let chatID = try values.optionChatID()
     let includeMedia = values.flag("media")
     let store = try MessageStore(path: dbPath)
     let stats = try store.messageStats(

--- a/Sources/imsg/Commands/StickerCommand.swift
+++ b/Sources/imsg/Commands/StickerCommand.swift
@@ -74,6 +74,11 @@ enum StickerCommand {
     guard let file = values.option("file"), !file.isEmpty else {
       throw ParsedValuesError.missingOption("file")
     }
+    let explicitPart = try values.optionInt("targetPart", name: "target-part", minimum: 0)
+    let target = try StickerSendTarget.resolve(
+      rawTarget: values.option("attachTo"),
+      explicitPart: explicitPart
+    )
     let dbPath = values.option("db") ?? MessageStore.defaultPath
     let chatGUID: String
     if let directGUID = directStickerChatGUID(chat) {
@@ -87,19 +92,6 @@ enum StickerCommand {
       throw StickerSendValidationError.iMessageRequired
     }
 
-    let explicitPart: Int?
-    if let rawPart = values.option("targetPart") {
-      guard let parsed = Int(rawPart) else {
-        throw ParsedValuesError.invalidOption("target-part")
-      }
-      explicitPart = parsed
-    } else {
-      explicitPart = nil
-    }
-    let target = try StickerSendTarget.resolve(
-      rawTarget: values.option("attachTo"),
-      explicitPart: explicitPart
-    )
     if let target {
       guard try messageBelongsToChat(target.messageGUID, chatGUID, dbPath) else {
         throw StickerSendValidationError.targetNotInChat

--- a/Sources/imsg/Commands/TypingCommand.swift
+++ b/Sources/imsg/Commands/TypingCommand.swift
@@ -58,7 +58,7 @@ enum TypingCommand {
     let dbPath = values.option("db") ?? MessageStore.defaultPath
     let input = ChatTargetInput(
       recipient: values.option("to") ?? "",
-      chatID: values.optionInt64("chatID"),
+      chatID: try values.optionChatID(),
       chatIdentifier: values.option("chatIdentifier") ?? "",
       chatGUID: values.option("chatGUID") ?? ""
     )

--- a/Sources/imsg/Commands/WatchCommand.swift
+++ b/Sources/imsg/Commands/WatchCommand.swift
@@ -86,12 +86,12 @@ enum WatchCommand {
       }
   ) async throws {
     let dbPath = values.option("db") ?? MessageStore.defaultPath
-    let chatID = values.optionInt64("chatID")
+    let chatID = try values.optionChatID()
     let debounceString = values.option("debounce") ?? "250ms"
     guard let debounceInterval = DurationParser.parse(debounceString) else {
       throw ParsedValuesError.invalidOption("debounce")
     }
-    let sinceRowID = values.optionInt64("sinceRowID")
+    let sinceRowID = try values.optionInt64("sinceRowID", name: "since-rowid")
     let showAttachments = values.flag("attachments")
     let attachmentOptions = AttachmentQueryOptions(
       convertUnsupported: values.flag("convertAttachments"))

--- a/Sources/imsg/DurationParser.swift
+++ b/Sources/imsg/DurationParser.swift
@@ -4,6 +4,7 @@ enum DurationParser {
   static func parse(_ value: String) -> TimeInterval? {
     let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return nil }
+    if let seconds = Double(trimmed) { return validated(seconds) }
 
     let units: [(suffix: String, multiplier: Double)] = [
       ("ms", 0.001),
@@ -11,18 +12,23 @@ enum DurationParser {
       ("m", 60),
       ("h", 3600),
     ]
-    for unit in units {
-      if trimmed.hasSuffix(unit.suffix) {
-        let number = String(trimmed.dropLast(unit.suffix.count))
-        if let value = Double(number) {
-          return value * unit.multiplier
-        }
-        return nil
-      }
+    let scanner = Scanner(string: trimmed)
+    scanner.locale = Locale(identifier: "en_US_POSIX")
+    scanner.charactersToBeSkipped = nil
+    var seconds: TimeInterval = 0
+    while !scanner.isAtEnd {
+      guard let amount = scanner.scanDouble(), amount >= 0,
+        let unit = units.first(where: { scanner.scanString($0.suffix) != nil })
+      else { return nil }
+      seconds += amount * unit.multiplier
     }
-    if let value = Double(trimmed) {
-      return value
-    }
-    return nil
+    return validated(seconds)
+  }
+
+  private static func validated(_ seconds: TimeInterval) -> TimeInterval? {
+    guard seconds >= 0,
+      UInt64(exactly: (seconds * 1_000_000_000).rounded(.towardZero)) != nil
+    else { return nil }
+    return seconds
   }
 }

--- a/Sources/imsg/ParsedValues+Decode.swift
+++ b/Sources/imsg/ParsedValues+Decode.swift
@@ -30,14 +30,26 @@ extension ParsedValues {
     options[label] ?? []
   }
 
-  func optionInt(_ label: String) -> Int? {
-    guard let value = option(label) else { return nil }
-    return Int(value)
+  func optionInt(_ label: String, name: String? = nil, minimum: Int? = nil) throws -> Int? {
+    try integerOption(label, name: name, minimum: minimum)
   }
 
-  func optionInt64(_ label: String) -> Int64? {
-    guard let value = option(label) else { return nil }
-    return Int64(value)
+  func optionInt64(_ label: String, name: String? = nil, minimum: Int64? = nil) throws -> Int64? {
+    try integerOption(label, name: name, minimum: minimum)
+  }
+
+  func optionChatID() throws -> Int64? {
+    try optionInt64("chatID", name: "chat-id", minimum: 1)
+  }
+
+  private func integerOption<T: FixedWidthInteger>(
+    _ label: String, name: String?, minimum: T?
+  ) throws -> T? {
+    guard let raw = option(label) else { return nil }
+    guard let value = T(raw), minimum.map({ value >= $0 }) ?? true else {
+      throw ParsedValuesError.invalidOption(name ?? label)
+    }
+    return value
   }
 
   func optionRequired(_ label: String) throws -> String {

--- a/Tests/IMsgCoreTests/TypingIndicatorTests.swift
+++ b/Tests/IMsgCoreTests/TypingIndicatorTests.swift
@@ -3,6 +3,26 @@ import Testing
 
 @testable import IMsgCore
 
+@Test(arguments: [Double.nan, .infinity, -.infinity, -1, .greatestFiniteMagnitude])
+func typingIndicatorRejectsInvalidDurationBeforeStarting(duration: Double) async {
+  var didStart = false
+  do {
+    try await TypingIndicator.typeForDuration(
+      chatIdentifier: "fixture-chat", duration: duration,
+      startTyping: { _ in
+        didStart = true
+        throw CancellationError()
+      },
+      stopTyping: { _ in Issue.record("Invalid duration must not stop typing") },
+      sleep: { _ in Issue.record("Invalid duration must not start a timer") })
+    Issue.record("Expected an invalid duration error")
+  } catch IMsgError.typingIndicatorFailed {
+  } catch {
+    Issue.record("Expected duration validation before starting, got \(error)")
+  }
+  #expect(!didStart)
+}
+
 @Test
 func typingIndicatorStopsOnCancellation() async {
   var events: [String] = []

--- a/Tests/imsgTests/CLIOptionValidationTests.swift
+++ b/Tests/imsgTests/CLIOptionValidationTests.swift
@@ -1,0 +1,124 @@
+import Commander
+import Foundation
+import Testing
+
+@testable import IMsgCore
+@testable import imsg
+
+private enum ValidationTestError: Error { case workStarted }
+
+@Test(arguments: ["not-a-number", "9223372036854775808", "", "0"])
+func numericReadOptionsRejectInvalidValuesBeforeOpeningDatabase(raw: String) async {
+  let cases: [(arguments: [String], option: String)] = [
+    (["chats", "--limit", raw], "limit"),
+    (["history", "--chat-id", raw], "chat-id"),
+    (["history", "--chat-id", "1", "--limit", raw], "limit"),
+    (["watch", "--chat-id", raw], "chat-id"),
+    (["watch", "--since-rowid", raw], "since-rowid"),
+    (["group", "--chat-id", raw], "chat-id"),
+    (["search", "--query", "hello", "--limit", raw], "limit"),
+    (["stats", "--chat-id", raw], "chat-id"),
+    (["scheduled", "list", "--limit", raw], "limit"),
+  ]
+  for testCase in cases where raw != "0" || testCase.option != "since-rowid" {
+    let (output, status) = await StdoutCapture.capture {
+      await CommandRouter().run(
+        argv: ["imsg"] + testCase.arguments + ["--db", "/nonexistent/imsg-validation.db"])
+    }
+    #expect(status == 1)
+    #expect(output.contains("Invalid value for option: --\(testCase.option)"))
+  }
+}
+
+@Test(arguments: ["send", "read", "typing"])
+func malformedChatIDCannotFallBackToRecipient(command: String) async throws {
+  let spec = try #require(CommandRouter().specs.first { $0.name == command })
+  let values = try CommandParser(signature: spec.signature).parse(
+    arguments: [
+      "--to", "+15550000000", "--chat-id", "invalid",
+    ] + (command == "send" ? ["--text", "fixture"] : []))
+  let runtime = RuntimeOptions(parsedValues: values)
+  var didWork = false
+  let store: (String) throws -> MessageStore = { _ in
+    didWork = true
+    throw ValidationTestError.workStarted
+  }
+  await expectInvalidOption("chat-id") {
+    switch command {
+    case "send":
+      try await SendCommand.run(
+        values: values, runtime: runtime, sendMessage: { _ in didWork = true },
+        storeFactory: store)
+    case "read":
+      try await ReadCommand.run(
+        values: values, runtime: runtime, storeFactory: store,
+        markAsRead: { _ in didWork = true })
+    default:
+      try await TypingCommand.run(
+        values: values, runtime: runtime, storeFactory: store,
+        startTyping: { _ in didWork = true })
+    }
+  }
+  #expect(!didWork)
+}
+
+@Test(arguments: ["invalid", "9223372036854775808", "-1"])
+func messagePartValidationPrecedesAttachmentStagingAndDispatch(raw: String) async {
+  let values = ParsedValues(
+    positional: [],
+    options: ["chat": ["iMessage;-;+15550000000"], "part": [raw], "file": ["fixture.png"]],
+    flags: [])
+  var didWork = false
+  await expectInvalidOption("part") {
+    try await SendRichCommand.run(
+      values: values, runtime: RuntimeOptions(parsedValues: values),
+      invokeBridge: { _, _ in
+        didWork = true
+        return [:]
+      },
+      stageAttachment: { _ in
+        didWork = true
+        return "/staged/fixture.png"
+      })
+  }
+  #expect(!didWork)
+}
+
+@Test(arguments: ["optionIndex", "chatID"])
+func pollRejectsInvalidNumericSelectorsBesideValidAlternatives(label: String) async {
+  let values = ParsedValues(
+    positional: ["vote"],
+    options: [
+      "chat": ["iMessage;-;+15550000000"], "poll": ["fixture-poll"],
+      "optionID": ["fixture-option"], label: ["invalid"],
+    ], flags: [])
+  var didWork = false
+  await expectInvalidOption(label == "chatID" ? "chat-id" : "option-index") {
+    try await PollCommand.run(
+      values: values, runtime: RuntimeOptions(parsedValues: values),
+      storeFactory: { _ in
+        didWork = true
+        throw ValidationTestError.workStarted
+      },
+      invokeBridge: { _, _ in
+        didWork = true
+        return [:]
+      })
+  }
+  #expect(!didWork)
+}
+
+private func expectInvalidOption(
+  _ name: String, operation: () async throws -> Void
+) async {
+  _ = await StdoutCapture.capture {
+    do {
+      try await operation()
+      Issue.record("Expected invalid --\(name) to fail before work")
+    } catch ParsedValuesError.invalidOption(let option) {
+      #expect(option == name)
+    } catch {
+      Issue.record("Expected invalid --\(name), got \(error)")
+    }
+  }
+}

--- a/Tests/imsgTests/CommandRouterTests.swift
+++ b/Tests/imsgTests/CommandRouterTests.swift
@@ -27,6 +27,17 @@ func commandRouterPrintsHelp() async {
 }
 
 @Test
+func commandRouterHonorsOptionTerminator() async {
+  for flag in ["--version", "-V", "--help", "-h"] {
+    let (output, status) = await StdoutCapture.capture {
+      await CommandRouter().run(argv: ["imsg", "completions", "--", flag])
+    }
+    #expect(status == 1)
+    #expect(output.contains("Unknown shell"))
+  }
+}
+
+@Test
 func commandRouterUnknownCommand() async {
   let router = CommandRouter()
   let (_, status) = await StdoutCapture.capture {

--- a/Tests/imsgTests/UtilitiesTests.swift
+++ b/Tests/imsgTests/UtilitiesTests.swift
@@ -12,7 +12,18 @@ func durationParserHandlesUnits() {
   #expect(DurationParser.parse("3m") == 180)
   #expect(DurationParser.parse("1h") == 3600)
   #expect(DurationParser.parse("5") == 5)
+  #expect(DurationParser.parse("2s500ms") == 2.5)
+  #expect(DurationParser.parse("1h30m") == 5400)
+  #expect(DurationParser.parse(".5s250ms") == 0.75)
+  #expect(DurationParser.parse("1e3ms") == 1)
   #expect(DurationParser.parse("bad") == nil)
+}
+
+@Test
+func durationParserRejectsNonfiniteOrUnrepresentableIntervals() {
+  for raw in ["nan", "inf", "-inf", "1e999s", "1e300h", "-1s", "1s-1ms"] {
+    #expect(DurationParser.parse(raw) == nil, "\(raw) must not reach a timer")
+  }
 }
 
 @Test
@@ -259,14 +270,21 @@ func cliISO8601MatchesFoundationFormatterConcurrently() async {
 func parsedValuesHelpers() throws {
   let values = ParsedValues(
     positional: ["first"],
-    options: ["limit": ["5", "9"], "name": ["bob"], "logLevel": ["debug"]],
+    options: [
+      "limit": ["5", "9"], "name": ["bob"], "logLevel": ["debug"],
+      "part": ["0"], "sinceRowID": ["-1"],
+    ],
     flags: ["jsonOutput", "verbose"]
   )
   #expect(values.flag("jsonOutput") == true)
   #expect(values.option("name") == "bob")
   #expect(values.optionValues("limit").count == 2)
-  #expect(values.optionInt("limit") == 9)
-  #expect(values.optionInt64("limit") == 9)
+  #expect(try values.optionInt("limit") == 9)
+  #expect(try values.optionInt64("limit") == 9)
+  #expect(try values.optionInt("part", minimum: 0) == 0)
+  #expect(try values.optionInt64("sinceRowID") == -1)
+  #expect(try values.optionChatID() == nil)
+  #expect(try values.optionInt("missing") == nil)
   #expect(values.argument(0) == "first")
   do {
     _ = try values.optionRequired("missing")

--- a/docs/watch.md
+++ b/docs/watch.md
@@ -98,7 +98,7 @@ could look like a direct message.
 
 Lower the debounce if you need lower latency and can tolerate occasional duplicate emissions during database churn. Raise it if downstream consumers can't keep up.
 
-`--debounce` accepts Go-style durations: `100ms`, `1s`, `2s500ms`.
+`--debounce` accepts non-negative durations in `ms`, `s`, `m`, and `h`, including compounds such as `2s500ms`. Bare numbers are seconds. Invalid, non-finite, and out-of-range values are rejected.
 
 ## RPC backpressure and overflow
 


### PR DESCRIPTION
Malformed CLI numbers could silently select a different operation: `watch --chat-id invalid` watched every chat, invalid chat IDs disappeared beside `--to`, and invalid `--part` values became part 0 for send, tapback, edit, and unsend. Limits and poll selectors had the same missing-versus-invalid ambiguity.

Use one throwing integer decoder and a shared positive chat-ID decoder across all command callers. Defaults apply only to omitted options. Existing stats, scheduled-message, sticker, and chat-background parsers now use the same validation; sticker target validation also precedes database lookup. Preserve explicit part 0, repeated-option last-value semantics, and the watch cursor's existing zero/negative behavior.

The same input-boundary pass fixes documented compound durations such as `2s500ms`, rejects non-finite/overflowing durations before typing starts, and lets Commander handle positional help/version-looking values after `--`. Production code grows by one line overall.

Validation:
- Numeric regressions failed before the repair across read, send/read/typing target, attachment-part, and poll-selector paths. Duration and `--` regressions also failed before their fixes.
- `make test`: 735 Swift tests plus native helper and docs tests passed.
- `make lint`: 16 existing warnings, zero serious violations.
- The built CLI rejected nine invalid-command cases before effects, including edit/unsend/tapback parts, and replayed a synthetic watch fixture using `2s500ms`. No messages or typing indicators were sent.
- Codex autoreview: no actionable P0–P2 findings.
