### PR TITLE
fix: preserve watch replay state and drain backlogs

### DIFF
--- a/Sources/IMsgCore/MessageStore+Messages.swift
+++ b/Sources/IMsgCore/MessageStore+Messages.swift
@@ -110,11 +110,13 @@ extension MessageStore {
         afterRowID: cursor,
         chatID: chatID,
         limit: limit,
-        includeReactions: includeReactions,
-        dedupeState: &dedupeState
+        includeReactions: includeReactions
       )
-      if !batch.messages.isEmpty {
-        return batch.messages
+      let visibleMessages = batch.messages.filter { message in
+        !isURLPreviewBalloon(message) || !dedupeState.shouldSkip(message)
+      }
+      if !visibleMessages.isEmpty {
+        return visibleMessages
       }
       guard batch.maxScannedRowID > cursor else {
         return []
@@ -202,8 +204,7 @@ extension MessageStore {
     afterRowID: Int64,
     chatID: Int64?,
     limit: Int,
-    includeReactions: Bool,
-    dedupeState: inout URLBalloonDedupeState
+    includeReactions: Bool
   ) throws -> MessagesAfterBatch {
     guard limit > 0 else {
       return MessagesAfterBatch(messages: [], maxScannedRowID: afterRowID)
@@ -250,11 +251,7 @@ extension MessageStore {
           return .suppress
         }
       )
-      let visibleMessages = coalesced.filter { message in
-        guard isURLPreviewBalloon(message) else { return true }
-        return !dedupeState.shouldSkip(message)
-      }
-      return MessagesAfterBatch(messages: visibleMessages, maxScannedRowID: maxScannedRowID)
+      return MessagesAfterBatch(messages: coalesced, maxScannedRowID: maxScannedRowID)
     }
   }
 

--- a/Sources/IMsgCore/MessageWatcher.swift
+++ b/Sources/IMsgCore/MessageWatcher.swift
@@ -269,12 +269,12 @@ private final class WatchState: @unchecked Sendable {
     if stopped { return }
     defer { didPoll() }
     do {
+      let previousCursor = cursor
       let batch = try store.messagesAfterBatch(
         afterRowID: cursor,
         chatID: chatID,
         limit: configuration.batchLimit,
-        includeReactions: configuration.includeReactions,
-        dedupeState: &urlBalloonDedupe
+        includeReactions: configuration.includeReactions
       )
       for message in batch.messages {
         switch yieldDecision(for: message) {
@@ -285,12 +285,10 @@ private final class WatchState: @unchecked Sendable {
         case .skip:
           continue
         }
-        guard filter.allows(message) else {
-          if message.rowID > cursor {
-            cursor = message.rowID
-          }
-          continue
-        }
+        cursor = max(cursor, message.rowID)
+        // Commit dedupe only for rows reached after chat resolution; later rows must survive retries.
+        if store.isURLPreviewBalloon(message), urlBalloonDedupe.shouldSkip(message) { continue }
+        guard filter.allows(message) else { continue }
         switch continuation.yield(message) {
         case .enqueued:
           // This is the last cursor guaranteed to reach the consumer if a later yield overflows.
@@ -305,12 +303,11 @@ private final class WatchState: @unchecked Sendable {
           stopSources()
           return
         }
-        if message.rowID > cursor {
-          cursor = message.rowID
-        }
       }
-      if batch.maxScannedRowID > cursor {
-        cursor = batch.maxScannedRowID
+      cursor = max(cursor, batch.maxScannedRowID)
+      if cursor > previousCursor {
+        // Drain in bounded turns so cancellation can run without waiting for the fallback timer.
+        queue.async { self.poll() }
       }
     } catch {
       finish(throwing: error)

--- a/Tests/IMsgCoreTests/MessageWatcherReplayTests.swift
+++ b/Tests/IMsgCoreTests/MessageWatcherReplayTests.swift
@@ -16,6 +16,72 @@ private func firstReplayMessages(
   return messages
 }
 
+@Test(.timeLimit(.minutes(1)))
+func messageWatcherRetainsPreviewsAcrossUnresolvedChatRetry() async throws {
+  let db = try makeURLPreviewTestDB()
+  let now = Date(timeIntervalSince1970: 1_700_000_000)
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123')")
+  for (offset, text) in [
+    "https://example.com/first", "unresolved", "https://example.com/later",
+    "https://example.com/first", "done",
+  ].enumerated() {
+    let rowID = Int64(offset + 1)
+    try insertURLPreviewTestMessage(
+      db, rowID: rowID, text: text, guid: "message-\(rowID)",
+      balloonBundleID: text.hasPrefix("https:") ? MessageStore.urlPreviewBalloonBundleID : nil,
+      date: now.addingTimeInterval(Double(offset))
+    )
+  }
+  try db.run("DELETE FROM chat_message_join WHERE message_id = 2")
+  let store = try MessageStore(connection: db, path: ":memory:")
+  let polls = WatcherPollController()
+  defer { polls.releaseAll() }
+  let firstPoll = polls.pauseNextPoll()
+  let stream = MessageWatcher(store: store, didPoll: polls.didPoll).stream(
+    sinceRowID: -1,
+    configuration: MessageWatcherConfiguration(
+      debounceInterval: 0, fallbackPollInterval: nil, batchLimit: 10
+    )
+  )
+  await polls.waitUntilPaused(firstPoll)
+  _ = try store.withConnection { connection in
+    try connection.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 2)")
+  }
+  polls.release(firstPoll)
+
+  var received: [Int64] = []
+  for try await message in stream {
+    received.append(message.rowID)
+    if message.rowID == 5 { break }
+  }
+  #expect(received == [1, 2, 3, 5])
+}
+
+@Test(.timeLimit(.minutes(1)))
+func messageWatcherDrainsReplayWithoutFallbackOrFileEvents() async throws {
+  let fixture = try WatcherTestDatabase.makeMutableStore()
+  for rowID in 1...3 {
+    try fixture.insertMessage(Int64(rowID), "message-\(rowID)")
+  }
+  let stream = MessageWatcher(store: fixture.store).stream(
+    sinceRowID: -1,
+    configuration: MessageWatcherConfiguration(
+      debounceInterval: 0, fallbackPollInterval: nil, batchLimit: 1
+    )
+  )
+  let received = try await withThrowingTaskGroup(of: [Message].self) { group in
+    group.addTask { try await firstReplayMessages(3, from: stream) }
+    group.addTask {
+      try await Task.sleep(for: .seconds(3))
+      return []
+    }
+    let messages = try await group.next() ?? []
+    group.cancelAll()
+    return messages
+  }
+  #expect(received.map(\.rowID) == [1, 2, 3])
+}
+
 @Test
 func messagesAfterBatchAdvancesAcrossSuppressedLateURLPreview() throws {
   let db = try makeURLPreviewTestDB()
@@ -45,13 +111,11 @@ func messagesAfterBatchAdvancesAcrossSuppressedLateURLPreview() throws {
   )
 
   let store = try MessageStore(connection: db, path: ":memory:")
-  var dedupeState = URLBalloonDedupeState()
   let previewBatch = try store.messagesAfterBatch(
     afterRowID: 1,
     chatID: 1,
     limit: 1,
-    includeReactions: false,
-    dedupeState: &dedupeState
+    includeReactions: false
   )
   #expect(previewBatch.messages.isEmpty)
   #expect(previewBatch.maxScannedRowID == 2)
@@ -60,8 +124,7 @@ func messagesAfterBatchAdvancesAcrossSuppressedLateURLPreview() throws {
     afterRowID: previewBatch.maxScannedRowID,
     chatID: 1,
     limit: 1,
-    includeReactions: false,
-    dedupeState: &dedupeState
+    includeReactions: false
   )
   #expect(nextBatch.messages.map(\.rowID) == [3])
 }

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -359,7 +359,7 @@ Older Messages database schemas without scheduling columns return an invalid-par
 Params:
 
 - `chat_id` (int, optional) — omit for all-chat stream.
-- `since_rowid` (int, optional) — exclusive cursor.
+- `since_rowid` (int, optional) — positive values resume exclusively after that row; omitted or `0` starts at the current tail. Use `-1` to replay from the beginning.
 - `participants` (array, optional)
 - `start` / `end` (ISO 8601, optional)
 - `attachments` (bool, default `false`)

--- a/docs/watch.md
+++ b/docs/watch.md
@@ -31,7 +31,7 @@ imsg watch --chat-id 42 --since-rowid 9000 --json
 
 `--since-rowid` is exclusive: `9000` means "everything strictly after rowid 9000."
 
-If you don't pass `--since-rowid`, watch starts at the newest message at the moment of launch. Messages written before then are not replayed; use [`history`](history.md) for that.
+If you omit `--since-rowid` or pass `0`, watch starts at the newest message at the moment of launch. Messages written before then are not replayed; use [`history`](history.md) for that.
 
 ROWID cursors belong to one database generation. After replacing or restoring
 `chat.db`, discard cursors from the previous file and choose a starting cursor
@@ -96,7 +96,7 @@ could look like a direct message.
 - CLI default: `250ms`.
 - RPC default: `500ms` (RPC's typical caller is an agent more sensitive to outbound echo races).
 
-Lower the debounce if you need lower latency and can tolerate occasional duplicate emissions during database churn. Raise it if downstream consumers can't keep up.
+Lower the debounce if you need lower latency; raise it to give Messages more time to finish related database updates. Debounce controls event-triggered reads, not the rate at which a backlog is delivered.
 
 `--debounce` accepts non-negative durations in `ms`, `s`, `m`, and `h`, including compounds such as `2s500ms`. Bare numbers are seconds. Invalid, non-finite, and out-of-range values are rejected.
 
@@ -135,6 +135,7 @@ macOS sometimes drops or coalesces filesystem events — especially under heavy 
 `imsg watch` runs a low-frequency poll alongside the event watcher. If the cursor falls behind the actual rowid, the poller catches up and emits the missed rows. You don't configure this — it's always on.
 Each fallback poll also refreshes the file watches, so a rotated `chat.db-wal` or
 `chat.db-shm` is reopened without needing an external `touch chat.db`.
+Once a read advances the cursor, watch continues draining the backlog in bounded batches without waiting for another filesystem event or fallback interval.
 
 This is the fix for the long-standing "watch goes silent after a while" class of bug. See `CHANGELOG.md` 0.6.0 entry.
 


### PR DESCRIPTION
## Problem and repair

Watch could silently lose a URL preview after an earlier message appeared before its chat join. The database batch query advanced the stream's preview deduplication state for every fetched row, even when the watcher returned early to retry the unresolved row. The next query then suppressed a preview it had never delivered.

Batch reads now return candidates without mutating stream state. The watcher records deduplication only as it advances past resolved rows, preserving earlier emitted previews while leaving later rows eligible for retry. It also schedules another bounded read whenever its cursor advances, so replay drains without waiting five seconds between batches or stalling entirely when fallback polling is disabled. Filtering, overflow resume cursors, cancellation, and the shipped zero-cursor tail behavior are preserved. Docs clarify cursor and debounce behavior.

## Evidence

- Both regressions failed on the previous implementation: unresolved-chat replay returned `[1, 2, 5]` instead of `[1, 2, 3, 5]`; a three-row replay with batch size one and no fallback/file events stalled after its first batch.
- 31 focused watcher/forward-read tests passed, covering retries, deduplication, cursor compatibility, filtering, overflow, and sidecar rotation.
- `make test`: 737 Swift tests (437 CLI, 300 core), native bridge tests, and docs tests passed.
- `make lint`: passed with 16 existing warnings and no serious violations. Codex autoreview found no actionable P0–P2 findings.
- Built JSON-RPC executable replayed 300 synthetic outbound rows in order in 1.18 seconds, then acknowledged unsubscribe and exited cleanly. No live messages were sent or changed. A separate inbound run exposed repeated PhoneNumberKit construction during contact-name lookup; that owner-level performance repair is the next follow-up.

Production delta: 18 added / 24 removed, net **−6** lines. Regression tests add 63 net lines. No new configuration, protocol, or database schema.
