### PR TITLE
perf: reuse phone metadata for contact lookups

### DIFF
--- a/Sources/IMsgCore/ContactCatalog.swift
+++ b/Sources/IMsgCore/ContactCatalog.swift
@@ -44,21 +44,25 @@
       if lookup.contains("@") {
         return state.catalog.emailToName[lookup.lowercased()]
       }
-      let normalized = PhoneNumberNormalizer().normalize(lookup, region: region)
+      // Reuse parsed phone metadata under the catalog's lock, including concurrent lookups.
+      condition.lock()
+      defer { condition.unlock() }
+      let normalized = normalizer.normalize(lookup, region: region)
       return state.catalog.phoneToName[normalized]
     }
 
     func displayNames(for handles: [String], region: String) -> [String: String] {
       let state = snapshot(region: region)
       guard !state.unavailable else { return [:] }
-      let lookupNormalizer = PhoneNumberNormalizer()
+      condition.lock()
+      defer { condition.unlock() }
       var resolved: [String: String] = [:]
       for handle in handles {
         let lookup = Self.normalizedLookupHandle(handle)
         let name =
           lookup.contains("@")
           ? state.catalog.emailToName[lookup.lowercased()]
-          : state.catalog.phoneToName[lookupNormalizer.normalize(lookup, region: region)]
+          : state.catalog.phoneToName[normalizer.normalize(lookup, region: region)]
         if let name { resolved[handle] = name }
       }
       return resolved

--- a/Tests/IMsgCoreTests/ContactResolverTests.swift
+++ b/Tests/IMsgCoreTests/ContactResolverTests.swift
@@ -255,6 +255,8 @@ func noOpContactResolverCanRepresentUnavailableContacts() {
         entered.signal()
         let name = resolver.displayName(for: "+15551234567")
         #expect(name == (changingSource ? "Bob" : "Alice"))
+        let names = resolver.displayNames(for: ["+15551234567", "absent@example.test"])
+        #expect(names == ["+15551234567": changingSource ? "Bob" : "Alice"])
         group.leave()
       }
     }
@@ -284,6 +286,23 @@ func noOpContactResolverCanRepresentUnavailableContacts() {
     _ = resolver.resolver(region: "FR").searchByName("Alice")
 
     #expect(resolver.cachedRegionCount == 2)
+    #expect(source.loadCount == 1)
+  }
+
+  @Test
+  func contactCatalogKeepsConcurrentRegionalLookupsIndependent() {
+    let source = ContactSourceHarness(records: [
+      contactRecord(name: "UK contact", phone: "+447700900000"),
+      contactRecord(name: "US contact", phone: "+16502530000"),
+    ])
+    let resolver = ContactResolver(region: "US", source: source.source)
+    let british = resolver.resolver(region: "GB")
+    DispatchQueue.concurrentPerform(iterations: 8) { _ in
+      #expect(british.displayName(for: "07700 900000") == "UK contact")
+      #expect(resolver.displayName(for: "650 253 0000") == "US contact")
+      #expect(british.displayNames(for: ["07700 900000"]) == ["07700 900000": "UK contact"])
+      #expect(resolver.displayNames(for: ["650 253 0000"]) == ["650 253 0000": "US contact"])
+    }
     #expect(source.loadCount == 1)
   }
 #endif

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -61,6 +61,8 @@ SSH sessions can use the read-only database path described below.
 
 When neither Contacts source is readable, JSON output leaves resolved name fields empty. A long-running `imsg rpc` child observes Contacts changes and periodically rechecks authorization, so grants and contact edits become visible without restarting. Revocation clears cached names; a transient Contacts read failure retains the last successful catalog until the next refresh.
 
+Phone-number matching reuses the resolver's parsed phone metadata across single, batch, and regional lookups. Repeated message-name resolution does not reload that metadata for each message; the same reuse applies to Contacts over SSH.
+
 On Macs with CardDAV accounts such as Google or Yahoo, Apple's Contacts framework may periodically write `Could not fetch group … :ABGroup` reconciliation messages to stderr. These messages are benign and do not come from `imsg`; a parent process that captures `imsg rpc --json` stderr should not report this specific framework message as an `imsg` error.
 
 ## Contacts over SSH


### PR DESCRIPTION
## Problem and repair

Contact-name lookup constructed a new PhoneNumberKit parser for every single phone lookup and every batch call, reparsing its metadata each time. The contact catalog already owns a parser for indexing contacts. Single, batch, and regional lookups now reuse that parser under the catalog's existing lock, so concurrent refreshes and lookups share one protected owner.

This follows PhoneNumberKit 5.0.8's documented allocation contract (README: allocate once and reuse). Direct inspection of `PhoneNumberUtility.init`, `MetadataManager`, `ParseManager`, and `RegexManager` confirmed metadata construction and parser/cache ownership. Contacts authorization, revocation, refresh, region handling, and SSH AddressBook routing are unchanged.

## Evidence

- An authorized synthetic catalog benchmark of 100 single lookups plus 100 batch lookups took **3.042 seconds before** and **0.0067 seconds after**, with every result checked. This isolates phone matching from native Contacts authorization cost; it is not a claim about whole-command latency.
- The built RPC correctly replayed and unsubscribed twice over a 100-message synthetic inbound fixture. Contacts is unavailable to this local process, and both versions still take roughly four seconds because macOS authorization checks dominate that path. That distinct performance limitation remains recorded for follow-up; this change preserves immediate authorization checks.
- Tests cover concurrent regional single/batch results and batch reads during coalesced refreshes. Existing Contacts grant/revocation, TTL, refresh, and SSH AddressBook tests pass.
- `make test`: 736 Swift tests on the pre-watcher base (437 CLI, 299 core), native helper and docs tests passed. The branch was then rebased onto the independently validated watcher repair; hosted CI exercises the combined tree.
- `make lint`: passed, 16 existing warnings, no serious violations. Codex autoreview: no actionable P0–P2 findings.

Production delta: **+4** net lines for locking the reused parser; tests add 19 lines. No new cache, configuration, dependency, schema, or permission behavior.
