### PR TITLE
fix: keep message queries unique and preserve event boundaries

### DIFF
--- a/Sources/IMsgCore/MessageStatsQueries.swift
+++ b/Sources/IMsgCore/MessageStatsQueries.swift
@@ -1,14 +1,5 @@
 import SQLite
 
-private func statsNonReactionPredicate(_ column: String) -> String {
-  """
-  (\(column) IS NULL OR (
-    \(column) NOT BETWEEN 2000 AND 2006
-    AND \(column) NOT BETWEEN 3000 AND 3006
-  ))
-  """
-}
-
 struct StatsQueryFilter {
   let whereClause: String
   let bindings: [Binding?]
@@ -17,7 +8,7 @@ struct StatsQueryFilter {
     var clauses: [String] = []
     var bindings: [Binding?] = []
     if schema.hasReactionColumns {
-      clauses.append(statsNonReactionPredicate("m.associated_message_type"))
+      clauses.append(nonReactionPredicate("m.associated_message_type"))
     }
     if let chatID {
       clauses.append("cmj.chat_id = ?")

--- a/Sources/IMsgCore/MessageStore+Chats.swift
+++ b/Sources/IMsgCore/MessageStore+Chats.swift
@@ -83,7 +83,7 @@ private struct UnreadMessagesQuery {
   let selection: MessageRowSelection
 
   init(store: MessageStore, chatIDs: [Int64]) {
-    let selection = MessageRowSelection(store: store, includeChatID: true)
+    let selection = MessageRowSelection(store: store, chatIDColumn: "cmj.chat_id")
     self.selection = selection
     let placeholders = Array(repeating: "?", count: chatIDs.count).joined(separator: ", ")
     self.sql = """

--- a/Sources/IMsgCore/MessageStore+HistoryMetadata.swift
+++ b/Sources/IMsgCore/MessageStore+HistoryMetadata.swift
@@ -76,8 +76,7 @@ extension MessageStore {
       LEFT JOIN handle h ON r.handle_id = h.ROWID
       WHERE r.associated_message_guid IS NOT NULL
         AND r.associated_message_guid != ''
-        AND r.associated_message_type >= 2000
-        AND r.associated_message_type <= 3006
+        AND \(reactionPredicate("r.associated_message_type"))
       """
 
     try withConnection { db in

--- a/Sources/IMsgCore/MessageStore+MessageConstruction.swift
+++ b/Sources/IMsgCore/MessageStore+MessageConstruction.swift
@@ -70,10 +70,10 @@ extension MessageStore {
 
   func precedingTextMessageForURLPreview(_ preview: Message, db: Connection) throws -> Message? {
     guard isURLPreviewBalloon(preview) else { return nil }
-    let selection = MessageRowSelection(store: self, includeChatID: true)
+    let selection = MessageRowSelection(store: self, chatIDColumn: "cmj.chat_id")
     let reactionFilter =
       schema.hasReactionColumns
-      ? "AND (m.associated_message_type IS NULL OR m.associated_message_type < 2000 OR m.associated_message_type > 3006)"
+      ? "AND \(nonReactionPredicate("m.associated_message_type"))"
       : ""
     let sql = """
       SELECT \(selection.selectList)

--- a/Sources/IMsgCore/MessageStore+MessageRows.swift
+++ b/Sources/IMsgCore/MessageStore+MessageRows.swift
@@ -92,11 +92,16 @@ struct MessagesAfterBatch {
 }
 
 struct MessageRowSelection {
+  // ROWID cursors represent physical messages, even when a row belongs to multiple chats.
+  static let canonicalChatID =
+    "(SELECT MIN(chat_id) FROM chat_message_join WHERE message_id = m.ROWID)"
+  static let scopedChatJoin = "JOIN chat_message_join cmj ON m.ROWID = cmj.message_id"
+
   let selectList: String
   let columns: MessageRowColumns
 
-  init(store: MessageStore, includeChatID: Bool) {
-    let columns = MessageRowColumns.message(chatID: includeChatID ? "chat_id" : nil)
+  init(store: MessageStore, chatIDColumn: String? = nil) {
+    let columns = MessageRowColumns.message(chatID: chatIDColumn == nil ? nil : "chat_id")
     let schema = store.schema
     let bodyColumn = schema.hasAttributedBody ? "m.attributedBody" : "NULL"
     let guidColumn = schema.hasReactionColumns ? "m.guid" : "NULL"
@@ -120,7 +125,7 @@ struct MessageRowSelection {
       ? "CASE WHEN \(pollCandidatePredicate) THEN m.message_summary_info ELSE NULL END" : "NULL"
     let isReadColumn = schema.hasIsReadColumn ? "m.is_read" : "NULL"
     let dateReadColumn = schema.hasDateReadColumn ? "m.date_read" : "NULL"
-    let chatColumn = includeChatID ? ", cmj.chat_id AS \(columns.chatID!)" : ""
+    let chatColumn = chatIDColumn.map { ", \($0) AS chat_id" } ?? ""
 
     let selectList = """
       m.ROWID AS \(columns.rowID)\(chatColumn), m.handle_id AS \(columns.handleID),

--- a/Sources/IMsgCore/MessageStore+Messages.swift
+++ b/Sources/IMsgCore/MessageStore+Messages.swift
@@ -61,13 +61,13 @@ extension MessageStore {
           fallbackReplacementUsed: {
             usedFallbackReplacement = true
           }
-        ).sorted(by: messageHistoryNewestFirst)
+        ).sorted(by: messageNewestFirst)
 
         if messages.count < physicalLimit || (coalesced.count >= limit && !usedFallbackReplacement)
         {
           return Array(coalesced.prefix(limit))
         }
-        guard let nextLimit = nextHistoryPhysicalLimit(after: physicalLimit) else {
+        guard let nextLimit = nextMessageQueryLimit(after: physicalLimit) else {
           return Array(coalesced.prefix(limit))
         }
         physicalLimit = nextLimit
@@ -75,12 +75,12 @@ extension MessageStore {
     }
   }
 
-  private func nextHistoryPhysicalLimit(after current: Int) -> Int? {
+  func nextMessageQueryLimit(after current: Int) -> Int? {
     guard current > 0, current <= Int.max / 2 else { return nil }
     return current * 2
   }
 
-  private func messageHistoryNewestFirst(_ lhs: Message, _ rhs: Message) -> Bool {
+  func messageNewestFirst(_ lhs: Message, _ rhs: Message) -> Bool {
     if lhs.date == rhs.date {
       return lhs.rowID > rhs.rowID
     }
@@ -188,7 +188,7 @@ extension MessageStore {
             hasMore: false
           )
         }
-        guard let nextLimit = nextHistoryPhysicalLimit(after: physicalLimit) else {
+        guard let nextLimit = nextMessageQueryLimit(after: physicalLimit) else {
           return MessagesAfterPage(
             messages: visibleMessages,
             nextRowID: physicalMessages.last?.rowID ?? afterRowID,

--- a/Sources/IMsgCore/MessageStore+Polls.swift
+++ b/Sources/IMsgCore/MessageStore+Polls.swift
@@ -98,7 +98,7 @@ extension MessageStore {
   }
 
   private func decodedPollOptions(guid: String, db: Connection) throws -> [MessagePollOption] {
-    let selection = MessageRowSelection(store: self, includeChatID: false)
+    let selection = MessageRowSelection(store: self)
     let sql: String
     let bindings: [Binding?]
     if schema.hasReactionColumns {
@@ -147,7 +147,7 @@ extension MessageStore {
 
   private func latestOutboundPollVoteOptionIDs(guid: String, db: Connection) throws -> [String] {
     guard schema.hasReactionColumns else { return [] }
-    let selection = MessageRowSelection(store: self, includeChatID: false)
+    let selection = MessageRowSelection(store: self)
     let rows = try db.prepareRowIterator(
       """
       SELECT \(selection.selectList)

--- a/Sources/IMsgCore/MessageStore+Queries.swift
+++ b/Sources/IMsgCore/MessageStore+Queries.swift
@@ -1,6 +1,14 @@
 import Foundation
 import SQLite
 
+func reactionPredicate(_ column: String) -> String {
+  "(\(column) BETWEEN 2000 AND 2006 OR \(column) BETWEEN 3000 AND 3006)"
+}
+
+func nonReactionPredicate(_ column: String) -> String {
+  "(\(column) IS NULL OR NOT \(reactionPredicate(column)))"
+}
+
 struct ChatMessagesQuery {
   let sql: String
   let bindings: [Binding?]
@@ -8,17 +16,17 @@ struct ChatMessagesQuery {
   let fallbackChatID: Int64
 
   init(store: MessageStore, chatID: ChatID, limit: Int, filter: MessageFilter?) {
-    self.selection = MessageRowSelection(store: store, includeChatID: false)
+    self.selection = MessageRowSelection(store: store)
     let destinationCallerColumn =
       store.schema.hasDestinationCallerID ? "m.destination_caller_id" : "NULL"
     let reactionFilter =
       store.schema.hasReactionColumns
-      ? " AND (m.associated_message_type IS NULL OR m.associated_message_type < 2000 OR m.associated_message_type > 3006)"
+      ? " AND \(nonReactionPredicate("m.associated_message_type"))"
       : ""
     var sql = """
       SELECT \(selection.selectList)
       FROM message m
-      JOIN chat_message_join cmj ON m.ROWID = cmj.message_id
+      \(MessageRowSelection.scopedChatJoin)
       LEFT JOIN handle h ON m.handle_id = h.ROWID
       WHERE cmj.chat_id = ?\(reactionFilter)
       """
@@ -44,7 +52,7 @@ struct ChatMessagesQuery {
       }
     }
 
-    sql += " ORDER BY m.date DESC LIMIT ?"
+    sql += " ORDER BY m.date DESC, m.ROWID DESC LIMIT ?"
     bindings.append(limit)
 
     self.sql = sql
@@ -66,18 +74,19 @@ struct MessagesAfterQuery {
     limit: Int,
     includeReactions: Bool
   ) {
-    self.selection = MessageRowSelection(store: store, includeChatID: true)
+    self.selection = MessageRowSelection(
+      store: store, chatIDColumn: chatID == nil ? MessageRowSelection.canonicalChatID : nil)
     let reactionFilter: String
     if includeReactions || !store.schema.hasReactionColumns {
       reactionFilter = ""
     } else {
       reactionFilter =
-        " AND (m.associated_message_type IS NULL OR m.associated_message_type < 2000 OR m.associated_message_type > 3006)"
+        " AND \(nonReactionPredicate("m.associated_message_type"))"
     }
     var sql = """
       SELECT \(selection.selectList)
       FROM message m
-      LEFT JOIN chat_message_join cmj ON m.ROWID = cmj.message_id
+      \(chatID == nil ? "" : MessageRowSelection.scopedChatJoin)
       LEFT JOIN handle h ON m.handle_id = h.ROWID
       WHERE m.ROWID > ?\(reactionFilter)
       """
@@ -102,12 +111,13 @@ struct LatestSentMessageQuery {
   let fallbackChatID: Int64?
 
   init(store: MessageStore, text: String, chatID: ChatID?, since date: Date) {
-    self.selection = MessageRowSelection(store: store, includeChatID: true)
+    self.selection = MessageRowSelection(
+      store: store, chatIDColumn: chatID == nil ? MessageRowSelection.canonicalChatID : nil)
     let bodyColumn = store.schema.hasAttributedBody ? "m.attributedBody" : "NULL"
     var sql = """
       SELECT \(selection.selectList)
       FROM message m
-      LEFT JOIN chat_message_join cmj ON m.ROWID = cmj.message_id
+      \(chatID == nil ? "" : MessageRowSelection.scopedChatJoin)
       LEFT JOIN handle h ON m.handle_id = h.ROWID
       WHERE m.is_from_me = 1
         AND m.date >= ?

--- a/Sources/IMsgCore/MessageStore+ReactionEvents.swift
+++ b/Sources/IMsgCore/MessageStore+ReactionEvents.swift
@@ -61,9 +61,10 @@ extension MessageStore {
     let bodyColumn = schema.hasAttributedBody ? "m.attributedBody" : "NULL"
     let destinationCallerColumn =
       schema.hasDestinationCallerID ? "m.destination_caller_id" : "NULL"
+    let chatColumn = chatID == nil ? MessageRowSelection.canonicalChatID : "NULL"
 
     var sql = """
-      SELECT m.ROWID AS reaction_rowid, cmj.chat_id AS chat_id,
+      SELECT m.ROWID AS reaction_rowid, \(chatColumn) AS chat_id,
              m.associated_message_type AS associated_message_type,
              m.associated_message_guid AS associated_message_guid,
              m.handle_id AS handle_id, h.id AS sender, m.is_from_me AS is_from_me,
@@ -72,13 +73,12 @@ extension MessageStore {
              \(bodyColumn) AS body,
              orig.ROWID AS orig_rowid
       FROM message m
-      LEFT JOIN chat_message_join cmj ON m.ROWID = cmj.message_id
+      \(chatID == nil ? "" : MessageRowSelection.scopedChatJoin)
       LEFT JOIN handle h ON m.handle_id = h.ROWID
       LEFT JOIN message orig ON (orig.guid = m.associated_message_guid
         OR m.associated_message_guid LIKE '%/' || orig.guid)
       WHERE m.ROWID > ?
-        AND m.associated_message_type >= 2000
-        AND m.associated_message_type <= 3006
+        AND \(reactionPredicate("m.associated_message_type"))
       """
     var bindings: [Binding?] = [afterRowID]
 

--- a/Sources/IMsgCore/MessageStore+Reactions.swift
+++ b/Sources/IMsgCore/MessageStore+Reactions.swift
@@ -18,8 +18,7 @@ private struct CurrentReactionsQuery {
       WHERE m.ROWID = ?
         AND m.guid IS NOT NULL
         AND m.guid != ''
-        AND r.associated_message_type >= 2000
-        AND r.associated_message_type <= 3006
+        AND \(reactionPredicate("r.associated_message_type"))
       ORDER BY r.date ASC
       """
     self.bindings = [messageID.rawValue]

--- a/Sources/IMsgCore/MessageStore+ReplyContext.swift
+++ b/Sources/IMsgCore/MessageStore+ReplyContext.swift
@@ -24,7 +24,7 @@ extension MessageStore {
   /// row is absent or the guid is empty.
   func resolveReplyParent(_ db: Connection, guid: String) throws -> ReplyParent? {
     guard !guid.isEmpty else { return nil }
-    let selection = MessageRowSelection(store: self, includeChatID: false)
+    let selection = MessageRowSelection(store: self)
     let sql = """
       SELECT \(selection.selectList)
       FROM message m
@@ -49,7 +49,7 @@ extension MessageStore {
     // Older/synthetic message tables may lack reply_to_guid; without it a poll
     // comment cannot be located, so skip the query rather than fail the pull.
     guard schema.hasReplyToGUIDColumn else { return nil }
-    let selection = MessageRowSelection(store: self, includeChatID: false)
+    let selection = MessageRowSelection(store: self)
     // The question caption is a plain message (associated_message_type 0 or NULL)
     // with no thread metadata. A threaded inline reply to the poll (type 100,
     // thread originator set) is NOT the question — exclude it so a reply is never

--- a/Sources/IMsgCore/MessageStore+Search.swift
+++ b/Sources/IMsgCore/MessageStore+Search.swift
@@ -8,10 +8,11 @@ private struct SearchMessagesQuery {
   let fallbackChatID: Int64? = nil
 
   init(store: MessageStore, text: String, exact: Bool, limit: Int) {
-    self.selection = MessageRowSelection(store: store, includeChatID: true)
+    self.selection = MessageRowSelection(
+      store: store, chatIDColumn: MessageRowSelection.canonicalChatID)
     let reactionFilter =
       store.schema.hasReactionColumns
-      ? " AND (m.associated_message_type IS NULL OR m.associated_message_type < 2000 OR m.associated_message_type > 3006)"
+      ? " AND \(nonReactionPredicate("m.associated_message_type"))"
       : ""
     let textPredicate =
       exact
@@ -26,7 +27,6 @@ private struct SearchMessagesQuery {
     self.sql = """
       SELECT \(selection.selectList)
       FROM message m
-      LEFT JOIN chat_message_join cmj ON m.ROWID = cmj.message_id
       LEFT JOIN handle h ON m.handle_id = h.ROWID
       WHERE \(predicate)\(reactionFilter)
       ORDER BY m.date DESC, m.ROWID DESC
@@ -102,14 +102,14 @@ extension MessageStore {
           fallbackReplacementUsed: {
             usedFallbackReplacement = true
           }
-        ).sorted(by: searchMessagesNewestFirst)
+        ).sorted(by: messageNewestFirst)
 
         if candidateCount < physicalLimit
           || (coalesced.count >= limit && !usedFallbackReplacement)
         {
           return Array(coalesced.prefix(limit))
         }
-        guard let nextLimit = nextSearchPhysicalLimit(after: physicalLimit) else {
+        guard let nextLimit = nextMessageQueryLimit(after: physicalLimit) else {
           return Array(coalesced.prefix(limit))
         }
         physicalLimit = nextLimit
@@ -124,15 +124,4 @@ extension MessageStore {
     return candidate.range(of: text, options: [.caseInsensitive]) != nil
   }
 
-  private func nextSearchPhysicalLimit(after current: Int) -> Int? {
-    guard current > 0, current <= Int.max / 2 else { return nil }
-    return current * 2
-  }
-
-  private func searchMessagesNewestFirst(_ lhs: Message, _ rhs: Message) -> Bool {
-    if lhs.date == rhs.date {
-      return lhs.rowID > rhs.rowID
-    }
-    return lhs.date > rhs.date
-  }
 }

--- a/Sources/IMsgCore/MessageStore+URLPreviews.swift
+++ b/Sources/IMsgCore/MessageStore+URLPreviews.swift
@@ -132,15 +132,9 @@ extension MessageStore {
 
     let reactionFilter =
       schema.hasReactionColumns
-      ? """
-       AND (
-         next.associated_message_type IS NULL
-         OR next.associated_message_type < 2000
-         OR next.associated_message_type > 3006
-       )
-      """
+      ? "AND \(nonReactionPredicate("next.associated_message_type"))"
       : ""
-    let selection = MessageRowSelection(store: self, includeChatID: true)
+    let selection = MessageRowSelection(store: self, chatIDColumn: "cmj.chat_id")
 
     // Keep each VALUES block below SQLite's historical 999-variable limit.
     for start in stride(from: 0, to: pageBases.count, by: 400) {

--- a/Tests/IMsgCoreTests/MessageQueryInvariantTests.swift
+++ b/Tests/IMsgCoreTests/MessageQueryInvariantTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+
+@Test
+func messageQueriesKeepOnePhysicalRowAcrossChatMemberships() throws {
+  let db = try makeURLPreviewTestDB()
+  let date = Date(timeIntervalSince1970: 1_700_000_000)
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123')")
+  try insertURLPreviewTestMessage(
+    db, rowID: 1, text: "See https://example.com", guid: "base", date: date, isFromMe: true)
+  try insertURLPreviewTestMessage(
+    db, rowID: 2, text: "https://example.com", guid: "preview",
+    balloonBundleID: MessageStore.urlPreviewBalloonBundleID,
+    date: date.addingTimeInterval(1), isFromMe: true)
+  try insertURLPreviewTestMessage(
+    db, rowID: 3, text: "after", guid: "after", date: date.addingTimeInterval(2), isFromMe: true)
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (2, 1), (2, 2)")
+  let store = try MessageStore(connection: db, path: ":memory:")
+
+  let forward = try store.messagesAfter(afterRowID: 0, chatID: nil, limit: 10)
+  #expect(forward.map(\.rowID) == [1, 3])
+  // Stop before page enrichment on broken code, where duplicate row IDs trap in Dictionary.
+  try #require(Set(forward.map(\.rowID)).count == forward.count)
+  #expect(forward.map(\.chatID) == [1, 1])
+  #expect(
+    try store.searchMessages(query: "example.com", match: "contains", limit: 2).map(\.rowID) == [1])
+  #expect(
+    try store.latestSentMessage(matchingText: "See https://example.com", chatID: nil, since: date)?
+      .chatID == 1)
+
+  for limit in [1, 2] {
+    var cursor: Int64 = 0
+    var received: [Int64] = []
+    for _ in 0..<4 {
+      let page = try store.messagesAfterPage(afterRowID: cursor, chatID: nil, limit: limit)
+      received.append(contentsOf: page.messages.map(\.rowID))
+      if let first = page.messages.first, first.rowID == 1 {
+        #expect(first.urlPreview?.rowID == 2)
+      }
+      if !page.hasMore { break }
+      try #require(page.nextRowID > cursor)
+      cursor = page.nextRowID
+    }
+    #expect(received == [1, 3])
+  }
+  let scoped = try store.messagesAfterPage(afterRowID: 0, chatID: 2, limit: 1)
+  #expect(scoped.messages.map(\.rowID) == [1])
+  #expect(scoped.messages.first?.chatID == 2)
+  #expect(scoped.messages.first?.urlPreview?.rowID == 2)
+}
+
+@Test
+func historyOrdersEqualDatesBeforeApplyingLimit() throws {
+  let db = try makeURLPreviewTestDB()
+  let date = Date(timeIntervalSince1970: 1_700_000_000)
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123')")
+  for rowID: Int64 in 1...3 {
+    try insertURLPreviewTestMessage(
+      db, rowID: rowID, text: "message", guid: "m-\(rowID)", date: date)
+  }
+  let store = try MessageStore(connection: db, path: ":memory:")
+  #expect(try store.messages(chatID: 1, limit: 1).map(\.rowID) == [3])
+  #expect(try store.messages(chatID: 1, limit: 2).map(\.rowID) == [3, 2])
+}
+
+@Test
+func readQueriesKeepNonReactionAssociatedEventsAsPreviewBoundaries() throws {
+  let db = try makeURLPreviewTestDB()
+  let date = Date(timeIntervalSince1970: 1_700_000_000)
+  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123')")
+  try insertURLPreviewTestMessage(
+    db, rowID: 1, text: "See https://example.com", guid: "base", date: date)
+  try insertURLPreviewTestMessage(
+    db, rowID: 2, text: "gap event", guid: "gap", associatedMessageType: 2500,
+    date: date.addingTimeInterval(1))
+  try insertURLPreviewTestMessage(
+    db, rowID: 3, text: "https://example.com", guid: "preview",
+    balloonBundleID: MessageStore.urlPreviewBalloonBundleID, date: date.addingTimeInterval(2))
+  for (offset, type) in [2000, 2006, 3000, 3006].enumerated() {
+    let rowID = Int64(offset + 4)
+    try insertURLPreviewTestMessage(
+      db, rowID: rowID, text: "Reacted 🎉 to message", guid: "reaction-\(rowID)",
+      associatedMessageGUID: "p:0/base", associatedMessageType: type,
+      date: date.addingTimeInterval(Double(rowID)))
+  }
+  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (2, 4)")
+  let store = try MessageStore(connection: db, path: ":memory:")
+  #expect(try store.messages(chatID: 1, limit: 10).map(\.rowID) == [3, 2, 1])
+  #expect(try store.messagesAfter(afterRowID: 0, chatID: nil, limit: 10).map(\.rowID) == [1, 2, 3])
+  #expect(
+    try store.searchMessages(query: "gap event", match: "exact", limit: 1).map(\.rowID) == [2])
+  let page = try store.messagesAfterPage(afterRowID: 0, chatID: nil, limit: 1)
+  #expect(page.messages.map(\.rowID) == [1])
+  #expect(page.messages.first?.urlPreview == nil)
+  #expect(try store.reactionEventsAfter(afterRowID: 1, chatID: nil, limit: 1).map(\.rowID) == [4])
+  #expect(
+    try store.reactionEventsAfter(afterRowID: 1, chatID: nil, limit: 10).map(\.rowID) == [
+      4, 5, 6, 7,
+    ])
+  #expect(try store.reactionEventsAfter(afterRowID: 1, chatID: 2, limit: 1).first?.chatID == 2)
+}

--- a/docs/history.md
+++ b/docs/history.md
@@ -3,7 +3,7 @@ title: History
 description: "Read message history from one chat with optional date, participant, and attachment filters."
 ---
 
-`imsg history` reads messages from a single chat in chronological order. It's the bread-and-butter command for one-shot reads — search, archive, summarize, transcribe.
+`imsg history` reads messages from a single chat, newest first. Messages with equal timestamps are ordered by descending row ID before applying the limit.
 
 ## Basic read
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -294,6 +294,7 @@ Result:
 ```
 
 Search results always contain an empty `attachments` array.
+Across all-chat search and cursor reads, each physical message appears once. If Messages links it to multiple chats, `chat_id` is the lowest linked chat ID. An explicit chat filter preserves that chat's context.
 
 ### `messages.after`
 

--- a/docs/watch.md
+++ b/docs/watch.md
@@ -12,6 +12,7 @@ imsg watch --json
 ```
 
 You'll see every new inbound and outbound message across every chat the database covers.
+Each physical message is emitted once. If Messages links a row to multiple chats, an all-chat watch uses its lowest linked chat ID; `--chat-id` preserves the requested chat's context.
 
 ## Stream one chat
 


### PR DESCRIPTION
## Problem and repair

Message queries violated their physical-row cursor contract when Messages linked one message to multiple chats. The global join returned duplicate message IDs before `LIMIT`, which could leave a page empty without advancing its cursor or crash URL-preview enrichment when it built a dictionary. History also applied its limit before breaking timestamp ties, and several readers classified the entire interval between reaction-add and reaction-remove codes as reactions, silently discarding ordinary associated events.

All-chat reads now select one deterministic chat ID per message (the lowest linked ID) without multiplying rows. Explicit chat filters retain that chat's context and the indexed join. A shared projection makes that distinction visible to query owners. History orders by date and ROWID before limiting. History, search, forward reads, URL-preview boundaries, statistics, and reaction readers now share the exact add/remove predicates. Duplicate history/search ordering and limit-growth helpers were consolidated.

## Evidence

- Three regression tests failed before the fix with ten issues: duplicate global rows, incorrect equal-date history limits, missing non-reaction events, preview coalescence across an ordinary event, and incorrect limited reaction reads.
- Tests cover pagination limits one and two, trailing preview enrichment, scoped second-chat context, search, latest-sent context, all-chat reaction cardinality, and reaction boundaries.
- The real local schema confirms `chat_message_join` permits multiple distinct chats per message and indexes `message_id`; the repair preserves the efficient chat-scoped join. No private message content is included in proof.
- Built CLI/JSON-RPC proof against a synthetic multi-chat SQLite file verified five paging/search responses, cursor advancement across a preview, retained chat context, and the newest equal-timestamp history row.
- `make test`: 741 Swift tests (437 CLI, 304 core), native helper and docs tests passed before rebasing onto the independently validated native-image reader repair. Hosted CI checks the combined tree.
- `make lint`: passed with 16 existing warnings and no serious violations. Codex autoreview: no actionable P0–P2 findings.

Production delta: **−13** lines; regression tests add 103 lines. Docs explain stable global chat selection and newest-first history. No schema, configuration, or protocol changes.
