### PR TITLE
fix: search Unicode text and audio transcripts consistently

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "507c9e98ff3b67d55824b5ebb4dd7392b8c8006a20e5ff692513cd293438b6a4",
+  "originHash" : "b3fa12d78aeadf6d1a1ce8872ebe6ad9c54af75bdfe815307402323a9a1ff769",
   "pins" : [
     {
       "identity" : "commander",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "bd219c4ee9032fee3e009856f81fcc6ec09a85f4",
         "version" : "0.2.4"
+      }
+    },
+    {
+      "identity" : "csqlite",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stephencelis/CSQLite",
+      "state" : {
+        "revision" : "8ad83035460a3d1029a2c5a0cca4f980297a9ca2",
+        "version" : "3.53.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/steipete/Commander.git", from: "0.2.4"),
     .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.16.0"),
+    .package(url: "https://github.com/stephencelis/CSQLite", from: "3.50.4"),
     .package(url: "https://github.com/PhoneNumberKit/PhoneNumberKit.git", from: "5.0.8"),
   ],
   targets: {
@@ -19,6 +20,8 @@ let package = Package(
         name: "IMsgCore",
         dependencies: [
           .product(name: "SQLite", package: "SQLite.swift"),
+          .product(
+            name: "SQLiteSwiftCSQLite", package: "CSQLite", condition: .when(platforms: [.linux])),
           .product(name: "PhoneNumberKit", package: "PhoneNumberKit"),
         ],
         linkerSettings: [

--- a/Sources/IMsgCore/MessageStore+Attachments.swift
+++ b/Sources/IMsgCore/MessageStore+Attachments.swift
@@ -27,7 +27,7 @@ private struct AudioTranscriptionQuery {
       FROM message_attachment_join maj
       JOIN attachment a ON a.ROWID = maj.attachment_id
       WHERE maj.message_id = ?
-      LIMIT 1
+      ORDER BY a.ROWID ASC
       """
     self.bindings = [messageID.rawValue]
   }

--- a/Sources/IMsgCore/MessageStore+Search.swift
+++ b/Sources/IMsgCore/MessageStore+Search.swift
@@ -1,6 +1,42 @@
 import Foundation
 import SQLite
 
+#if os(Linux)
+  import SQLiteSwiftCSQLite
+#else
+  import SQLite3
+#endif
+
+func messageSearchMatches(_ candidate: String, query: String, exact: Bool) -> Bool {
+  if exact {
+    return candidate.caseInsensitiveCompare(query) == .orderedSame
+  }
+  return candidate.range(of: query, options: [.caseInsensitive]) != nil
+}
+
+func registerMessageSearch(in db: Connection) throws {
+  // SQLite.swift's block registration crashes on Linux (upstream #1071).
+  // This C callback captures no state and lives with the connection.
+  let result = sqlite3_create_function_v2(
+    db.handle, "imsg_search_text", 3, SQLITE_UTF8 | SQLITE_DETERMINISTIC, nil,
+    { context, _, args in
+      guard let args, let candidate = sqlite3_value_text(args[0]),
+        let query = sqlite3_value_text(args[1])
+      else {
+        sqlite3_result_int(context, 0)
+        return
+      }
+      let matches = messageSearchMatches(
+        String(cString: candidate), query: String(cString: query),
+        exact: sqlite3_value_int(args[2]) != 0)
+      sqlite3_result_int(context, matches ? 1 : 0)
+    }, nil, nil, nil)
+  guard result == SQLITE_OK else {
+    throw SQLite.Result.error(
+      message: String(cString: sqlite3_errmsg(db.handle)), code: result, statement: nil)
+  }
+}
+
 private struct SearchMessagesQuery {
   let sql: String
   let bindings: [Binding?]
@@ -14,16 +50,15 @@ private struct SearchMessagesQuery {
       store.schema.hasReactionColumns
       ? " AND \(nonReactionPredicate("m.associated_message_type"))"
       : ""
-    let textPredicate =
-      exact
-      ? "IFNULL(m.text, '') = ? COLLATE NOCASE"
-      : "IFNULL(m.text, '') LIKE ? ESCAPE '\\' COLLATE NOCASE"
     let attributedBodyCandidate =
       store.schema.hasAttributedBody
       ? " OR (IFNULL(m.text, '') = '' AND m.attributedBody IS NOT NULL)"
       : ""
-    let predicate = "(\(textPredicate)\(attributedBodyCandidate))"
-    let textBinding = exact ? text : SearchMessagesQuery.likePattern(for: text)
+    let audioCandidate =
+      store.schema.hasAudioMessageColumn && store.schema.hasAttachmentUserInfo
+      ? " OR m.is_audio_message != 0" : ""
+    let predicate =
+      "(imsg_search_text(IFNULL(m.text, ''), ?, ?)\(attributedBodyCandidate)\(audioCandidate))"
     self.sql = """
       SELECT \(selection.selectList)
       FROM message m
@@ -32,18 +67,7 @@ private struct SearchMessagesQuery {
       ORDER BY m.date DESC, m.ROWID DESC
       LIMIT ?
       """
-    self.bindings = [textBinding, limit]
-  }
-
-  private static func likePattern(for text: String) -> String {
-    var escaped = ""
-    for char in text {
-      if char == "\\" || char == "%" || char == "_" {
-        escaped.append("\\")
-      }
-      escaped.append(char)
-    }
-    return "%\(escaped)%"
+    self.bindings = [text, exact ? 1 : 0, limit]
   }
 }
 
@@ -75,7 +99,7 @@ extension MessageStore {
             columns: query.selection.columns,
             fallbackChatID: query.fallbackChatID
           )
-          guard searchText(decoded.text, matches: trimmed, exact: exact) else { continue }
+          guard messageSearchMatches(decoded.text, query: trimmed, exact: exact) else { continue }
           messages.append(
             try message(
               from: decoded,
@@ -94,7 +118,7 @@ extension MessageStore {
             guard let previous = try self.precedingTextMessageForURLPreview(preview, db: db) else {
               return nil
             }
-            guard self.searchText(previous.text, matches: trimmed, exact: exact) else {
+            guard messageSearchMatches(previous.text, query: trimmed, exact: exact) else {
               return nil
             }
             return .replace(previous)
@@ -115,13 +139,6 @@ extension MessageStore {
         physicalLimit = nextLimit
       }
     }
-  }
-
-  private func searchText(_ candidate: String, matches text: String, exact: Bool) -> Bool {
-    if exact {
-      return candidate.caseInsensitiveCompare(text) == .orderedSame
-    }
-    return candidate.range(of: text, options: [.caseInsensitive]) != nil
   }
 
 }

--- a/Sources/IMsgCore/MessageStore.swift
+++ b/Sources/IMsgCore/MessageStore.swift
@@ -26,6 +26,7 @@ public final class MessageStore: @unchecked Sendable {
       let location = Connection.Location.uri(uri, parameters: [.mode(.readOnly)])
       self.connection = try Connection(location, readonly: true)
       self.connection.busyTimeout = 5
+      try registerMessageSearch(in: self.connection)
       self.schema = try MessageStoreSchema(connection: self.connection)
     } catch {
       throw MessageStore.enhance(error: error, path: normalized)
@@ -55,6 +56,7 @@ public final class MessageStore: @unchecked Sendable {
     self.queue.setSpecific(key: queueKey, value: ())
     self.connection = connection
     self.connection.busyTimeout = 5
+    try registerMessageSearch(in: self.connection)
     self.schema = MessageStoreSchema(
       base: try MessageStoreSchema(connection: connection),
       hasAttributedBody: hasAttributedBody,

--- a/Tests/IMsgCoreTests/MessageStoreAttributedBodyTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreAttributedBodyTests.swift
@@ -330,6 +330,27 @@ private func makeAttributedBodySearchDatabase() throws -> Connection {
   return db
 }
 
+@Test(arguments: ["contains", "exact"])
+func searchMessagesMatchesUnicodeAcrossPlainAndAttributedBodies(match: String) throws {
+  let db = try makeAttributedBodySearchDatabase()
+  let date = Date(timeIntervalSince1970: 1_700_000_000)
+  try insertSearchMessage(db, rowID: 1, text: "CAFÉ", attributedText: nil, date: date)
+  try insertSearchMessage(db, rowID: 2, text: nil, attributedText: "CAFÉ", date: date)
+  let store = try MessageStore(connection: db, path: ":memory:")
+  #expect(try store.searchMessages(query: "café", match: match, limit: 2).map(\.rowID) == [2, 1])
+}
+
+@Test(arguments: ["contains", "exact"])
+func searchMessagesTreatsSQLPatternCharactersLiterally(match: String) throws {
+  let db = try makeAttributedBodySearchDatabase()
+  let date = Date(timeIntervalSince1970: 1_700_000_000)
+  try insertSearchMessage(db, rowID: 1, text: "100%_\\done", attributedText: nil, date: date)
+  try insertSearchMessage(db, rowID: 2, text: "100xy\\done", attributedText: nil, date: date)
+  let store = try MessageStore(connection: db, path: ":memory:")
+  #expect(
+    try store.searchMessages(query: "100%_\\done", match: match, limit: 2).map(\.rowID) == [1])
+}
+
 private func insertSearchMessage(
   _ db: Connection,
   rowID: Int64,

--- a/Tests/IMsgCoreTests/MessageStoreAudioTranscriptionTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreAudioTranscriptionTests.swift
@@ -4,156 +4,35 @@ import Testing
 
 @testable import IMsgCore
 
-@Test
-func audioMessagesUseTranscriptionText() throws {
+@Test(arguments: [String?.none, "placeholder"], [false, true])
+func audioMessageQueriesUseAvailableTranscript(text: String?, leadingEmptyAttachment: Bool) throws {
   let db = try Connection(.inMemory)
-  try db.execute(
-    """
-    CREATE TABLE message (
-      ROWID INTEGER PRIMARY KEY,
-      handle_id INTEGER,
-      text TEXT,
-      date INTEGER,
-      is_from_me INTEGER,
-      service TEXT,
-      is_audio_message INTEGER
-    );
-    """
-  )
-  try db.execute("CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT);")
-  try db.execute("CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);")
-  try db.execute(
-    """
-    CREATE TABLE attachment (
-      ROWID INTEGER PRIMARY KEY,
-      filename TEXT,
-      transfer_name TEXT,
-      uti TEXT,
-      mime_type TEXT,
-      total_bytes INTEGER,
-      is_sticker INTEGER,
-      user_info BLOB
-    );
-    """
-  )
-  try db.execute(
-    "CREATE TABLE message_attachment_join (message_id INTEGER, attachment_id INTEGER);"
-  )
-
-  let now = Date()
+  try MessageDatabaseFixture.createSchema(
+    db, options: .init(includeAudioMessage: true, includeAttachmentUserInfo: true))
   try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123')")
   try db.run(
     """
     INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service, is_audio_message)
-    VALUES (1, 1, 'placeholder', ?, 0, 'iMessage', 1)
-    """,
-    TestDatabase.appleEpoch(now)
-  )
+    VALUES (1, 1, ?, 700000000000000000, 0, 'iMessage', 1)
+    """, text)
   try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1)")
-
+  if leadingEmptyAttachment {
+    try db.run("INSERT INTO attachment(ROWID) VALUES (1)")
+    try db.run("INSERT INTO message_attachment_join(message_id, attachment_id) VALUES (1, 1)")
+  }
+  let transcript = "CAFÉ voice transcript"
   let info = try PropertyListSerialization.data(
-    fromPropertyList: ["audio-transcription": "test transcript"],
-    format: .binary,
-    options: 0
-  )
-  let infoBlob = Blob(bytes: [UInt8](info))
-  try db.run(
-    """
-    INSERT INTO attachment(
-      ROWID,
-      filename,
-      transfer_name,
-      uti,
-      mime_type,
-      total_bytes,
-      is_sticker,
-      user_info
-    )
-    VALUES (1, '', '', '', '', 0, 0, ?)
-    """,
-    infoBlob
-  )
-  try db.run("INSERT INTO message_attachment_join(message_id, attachment_id) VALUES (1, 1)")
-
+    fromPropertyList: ["audio-transcription": transcript], format: .binary, options: 0)
+  try db.run("INSERT INTO attachment(ROWID, user_info) VALUES (2, ?)", Blob(bytes: Array(info)))
+  try db.run("INSERT INTO message_attachment_join(message_id, attachment_id) VALUES (1, 2)")
   let store = try MessageStore(connection: db, path: ":memory:")
-  let messages = try store.messages(chatID: 1, limit: 10)
-  #expect(messages.count == 1)
-  #expect(messages.first?.text == "test transcript")
-}
 
-@Test
-func messagesAfterUsesAudioTranscriptionText() throws {
-  let db = try Connection(.inMemory)
-  try db.execute(
-    """
-    CREATE TABLE message (
-      ROWID INTEGER PRIMARY KEY,
-      handle_id INTEGER,
-      text TEXT,
-      date INTEGER,
-      is_from_me INTEGER,
-      service TEXT,
-      is_audio_message INTEGER
-    );
-    """
-  )
-  try db.execute("CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT);")
-  try db.execute("CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);")
-  try db.execute(
-    """
-    CREATE TABLE attachment (
-      ROWID INTEGER PRIMARY KEY,
-      filename TEXT,
-      transfer_name TEXT,
-      uti TEXT,
-      mime_type TEXT,
-      total_bytes INTEGER,
-      is_sticker INTEGER,
-      user_info BLOB
-    );
-    """
-  )
-  try db.execute(
-    "CREATE TABLE message_attachment_join (message_id INTEGER, attachment_id INTEGER);"
-  )
-
-  let now = Date()
-  try db.run("INSERT INTO handle(ROWID, id) VALUES (1, '+123')")
-  try db.run(
-    """
-    INSERT INTO message(ROWID, handle_id, text, date, is_from_me, service, is_audio_message)
-    VALUES (1, 1, 'placeholder', ?, 0, 'iMessage', 1)
-    """,
-    TestDatabase.appleEpoch(now)
-  )
-  try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 1)")
-
-  let info = try PropertyListSerialization.data(
-    fromPropertyList: ["audio-transcription": "test transcript"],
-    format: .binary,
-    options: 0
-  )
-  let infoBlob = Blob(bytes: [UInt8](info))
-  try db.run(
-    """
-    INSERT INTO attachment(
-      ROWID,
-      filename,
-      transfer_name,
-      uti,
-      mime_type,
-      total_bytes,
-      is_sticker,
-      user_info
-    )
-    VALUES (1, '', '', '', '', 0, 0, ?)
-    """,
-    infoBlob
-  )
-  try db.run("INSERT INTO message_attachment_join(message_id, attachment_id) VALUES (1, 1)")
-
-  let store = try MessageStore(connection: db, path: ":memory:")
-  let messages = try store.messagesAfter(afterRowID: 0, chatID: 1, limit: 10)
-  #expect(messages.count == 1)
-  #expect(messages.first?.text == "test transcript")
+  #expect(try store.messages(chatID: 1, limit: 1).first?.text == transcript)
+  #expect(try store.messagesAfter(afterRowID: 0, chatID: 1, limit: 1).first?.text == transcript)
+  #expect(
+    try store.searchMessages(query: "café", match: "contains", limit: 1).first?.text == transcript)
+  #expect(
+    try store.searchMessages(query: "café voice transcript", match: "exact", limit: 1).first?.text
+      == transcript)
+  #expect(try store.searchMessages(query: "placeholder", match: "exact", limit: 1).isEmpty)
 }

--- a/TestsLinux/LinuxReadCoreTests.swift
+++ b/TestsLinux/LinuxReadCoreTests.swift
@@ -180,3 +180,14 @@ private func appleEpoch(_ date: Date) -> Int64 {
   let seconds = date.timeIntervalSince1970 - MessageStore.appleEpochOffset
   return Int64(seconds * 1_000_000_000)
 }
+
+@Test(arguments: ["contains", "exact"])
+func linuxSearchMatchesUnicode(match: String) throws {
+  let databaseURL = try makeTemporaryDatabase()
+  defer { try? FileManager.default.removeItem(at: databaseURL.deletingLastPathComponent()) }
+  try seedDatabase(at: databaseURL)
+  let writer = try Connection(databaseURL.path)
+  try writer.run("UPDATE message SET text = 'CAFÉ' WHERE ROWID = 2")
+  let store = try MessageStore(path: databaseURL.path)
+  #expect(try store.searchMessages(query: "café", match: match, limit: 1).map(\.rowID) == [2])
+}

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -294,6 +294,7 @@ Result:
 ```
 
 Search results always contain an empty `attachments` array.
+Matching is case-insensitive for Unicode text and uses the text shown by history, including attributed bodies and stored audio transcripts. Characters such as `%`, `_`, and `\` are matched literally.
 Across all-chat search and cursor reads, each physical message appears once. If Messages links it to multiple chats, `chat_id` is the lowest linked chat ID. An explicit chat filter preserves that chat's context.
 
 ### `messages.after`


### PR DESCRIPTION
Search now uses the same Unicode case-insensitive matcher for SQL candidates and decoded message bodies, so `café` finds plain-text `CAFÉ` as well as attributed text. Audio messages also enter the candidate set, and transcript decoding scans attachments in order instead of stopping at an empty first attachment. Exact and contains matching keep `%`, `_`, and backslash literal.

The matcher is registered with SQLite's public C callback API. SQLite.swift's block-based custom-function registration crashed on Linux during validation ([upstream #1071](https://github.com/stephencelis/SQLite.swift/issues/1071)); the Linux target explicitly depends on the CSQLite backend already used by SQLite.swift so both use the same connection implementation. macOS continues to use system SQLite.

Validation: the original implementation failed 15 regression assertions; the repaired implementation passes 742 Swift tests, native helper fixtures, documentation checks, and lint (16 existing warnings). All six Linux tests and the Linux CLI build pass in Swift 6.3.3, including exact/contains Unicode cases. Four built-CLI and four JSON-RPC searches against a synthetic database verify Unicode and multi-attachment transcripts. Independent Codex review found no actionable P0–P2 defects. No real Messages data or sends were used.

Production source grows by 19 lines for the shared matcher and portable callback boundary; the manifest adds three lines. Consolidating audio fixtures removes 89 net test lines. This also documents search behavior in the RPC reference.
