### PR TITLE
fix: retain subscription ownership during cancellation

### DIFF
--- a/Sources/imsg/RPCServer+Support.swift
+++ b/Sources/imsg/RPCServer+Support.swift
@@ -208,13 +208,9 @@ actor SubscriptionStore {
     return .activated
   }
 
-  func removeForCancellation(_ id: Int) -> Task<Void, Never>? {
-    guard let entry = entries.removeValue(forKey: id) else { return nil }
-    resumeEmptyWaitersIfNeeded()
-    if case .active(_, let task) = entry {
-      return task
-    }
-    return nil
+  func cancel(_ id: Int) async {
+    guard let entry = entries[id] else { return }
+    await cancelEntries([id: entry])
   }
 
   func complete(_ reservation: Reservation) {
@@ -233,17 +229,24 @@ actor SubscriptionStore {
   func cancelAll() async {
     accepting = false
     resumeClosedWaiters()
-    let tasks = entries.values.compactMap { entry -> Task<Void, Never>? in
-      guard case .active(_, let task) = entry else { return nil }
-      return task
+    await cancelEntries(entries)
+  }
+
+  private func cancelEntries(_ snapshot: [Int: Entry]) async {
+    var tasks: [(Reservation, Task<Void, Never>)] = []
+    for (id, entry) in snapshot {
+      switch entry {
+      case .pending(let generation):
+        complete(Reservation(id: id, generation: generation))
+      case .active(let generation, let task):
+        task.cancel()
+        tasks.append((Reservation(id: id, generation: generation), task))
+      }
     }
-    entries.removeAll()
-    resumeEmptyWaitersIfNeeded()
-    for task in tasks {
-      task.cancel()
-    }
-    for task in tasks {
+    // Keep ownership while awaiting cleanup so overlapping callers drain the same tasks.
+    for (reservation, task) in tasks {
       await task.value
+      complete(reservation)
     }
   }
 

--- a/Sources/imsg/RPCServer+WatchHandlers.swift
+++ b/Sources/imsg/RPCServer+WatchHandlers.swift
@@ -148,10 +148,7 @@ extension RPCServer {
     guard subID > 0 else {
       throw RPCError.invalidParams("subscription must be a positive integer")
     }
-    if let task = await subscriptions.removeForCancellation(subID) {
-      task.cancel()
-      await task.value
-    }
+    await subscriptions.cancel(subID)
     // Awaiting the task makes this response the final output for the subscription.
     respond(id: id, result: ["ok": true])
   }

--- a/Tests/imsgTests/RPCSubscriptionStoreTests.swift
+++ b/Tests/imsgTests/RPCSubscriptionStoreTests.swift
@@ -26,3 +26,44 @@ func subscriptionStoreRejectsLimitsAndClosureWithoutConsumingIDs() async {
   #expect(await store.reserve() == .closed)
   #expect(await store.nextIDForTesting == 2)
 }
+
+@Test(arguments: [false, true])
+func subscriptionCancellationRetainsOwnershipUntilCleanupFinishes(unsubscribe: Bool) async throws {
+  let output = TestRPCOutput()
+  let server = RPCServer(databasePath: "/unused", verbose: false, output: output)
+  let store = server.subscriptions
+  guard case .reserved(let reservation) = await store.reserve() else {
+    Issue.record("reservation should succeed")
+    return
+  }
+  let cancelled = RuntimeGate()
+  let cleanup = RuntimeGate()
+  let task = Task {
+    await withTaskCancellationHandler {
+      await cleanup.wait()
+    } onCancel: {
+      Task { await cancelled.open() }
+    }
+  }
+  #expect(await store.activate(task, reservation: reservation) == .activated)
+
+  let first = Task {
+    if unsubscribe {
+      try await server.handleWatchUnsubscribe(id: 1, params: ["subscription": reservation.id])
+    } else {
+      await store.cancelAll()
+    }
+  }
+  await cancelled.wait()
+  #expect(await store.count == 1)
+  #expect(output.responses.isEmpty)
+
+  let shutdown = Task { await store.cancelAll() }
+  await store.waitUntilClosed()
+  #expect(await store.count == 1)
+  await cleanup.open()
+  try await first.value
+  await shutdown.value
+  #expect(await store.count == 0)
+  #expect(output.responses.count == (unsubscribe ? 1 : 0))
+}

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -115,6 +115,7 @@ Closing stdin stops admission, cancels and awaits every watch subscription,
 then drains all already accepted requests and flushes stdout before `run()`
 returns. Parent-task cancellation cancels subscriptions plus read/control work,
 but never cancels an already-started mutation or claims it did not execute.
+Overlapping shutdown and unsubscribe requests await the same subscription cleanup.
 Accepted mutations, including those not yet started, conservatively drain in
 FIFO order during normal EOF or parent cancellation; the server never invents
 a retry-safe result for work it already admitted.


### PR DESCRIPTION
Keep subscriptions owned until cancellation cleanup finishes. Previously, unsubscribe and shutdown removed active tasks before awaiting them. A concurrent shutdown could then see an empty store, flush stdout, and return while another caller was still draining a producer.

`SubscriptionStore` now owns cancellation for both paths. It cancels every selected task before awaiting any, retains active entries across suspension, and removes pending reservations immediately. Overlapping callers await the same tasks; the generation-checked completion path remains idempotent. Database watches and bridge event subscriptions share this owner.

Validation: a gate-controlled regression failed four assertions on the old implementation and now passes for overlapping shutdowns and shutdown during unsubscribe. Twelve focused lifecycle tests pass, including real RPC unsubscribe, EOF, parent cancellation, bridge events, and mutation drainage. Full `make test` and `make lint` pass (15 existing lint warnings); independent Codex review found no actionable P0–P2 issues. Tests use synthetic producers and no live messaging.

Production LOC is unchanged overall: the shared cancellation owner replaces task cancellation in the handler. Adds 41 lines of regression coverage and documents overlapping shutdown behavior.
