### PR TITLE
fix: unify poll and reaction state resolution

### DIFF
--- a/Sources/IMsgCore/MessageStore+HistoryMetadata.swift
+++ b/Sources/IMsgCore/MessageStore+HistoryMetadata.swift
@@ -57,13 +57,12 @@ extension MessageStore {
 
     var messageIDByGUID: [String: Int64] = [:]
     for message in messages where !message.guid.isEmpty {
-      messageIDByGUID[message.guid] = message.rowID
+      messageIDByGUID[message.guid.lowercased()] = message.rowID
     }
     guard !messageIDByGUID.isEmpty else { return [:] }
 
     var reactionsByMessageID: [Int64: [Reaction]] = [:]
-    var reactionIndexByMessageID: [Int64: [BulkReactionKey: Int]] = [:]
-    var matchedRows: [BulkReactionRow] = []
+    var matchedRows: [ReactionRow] = []
     let bodyColumn = schema.hasAttributedBody ? "r.attributedBody" : "NULL"
     // A reaction can be joined to a different chat than its target. Scan the indexed
     // associated-message rows once, then match only the requested GUIDs in memory.
@@ -83,147 +82,19 @@ extension MessageStore {
       let rows = try db.prepareRowIterator(sql)
       while let row = try rows.failableNext() {
         let associatedGUID = try stringValue(row, "associated_message_guid")
-        let baseGUID = baseAssociatedMessageGUID(from: associatedGUID)
+        let baseGUID = normalizeAssociatedGUID(associatedGUID).lowercased()
         guard let messageID = messageIDByGUID[baseGUID] else { continue }
 
-        let rowID = try int64Value(row, "reaction_rowid") ?? 0
-        let typeValue = try intValue(row, "associated_message_type") ?? 0
-        let sender = try stringValue(row, "sender")
-        let isFromMe = try boolValue(row, "is_from_me")
-        let date = try appleDate(from: int64Value(row, "date"))
-        let text = try stringValue(row, "text")
-        let body = try dataValue(row, "body")
-        let resolvedText = text.isEmpty ? TypedStreamParser.parseAttributedBody(body) : text
-        matchedRows.append(
-          BulkReactionRow(
-            rowID: rowID,
-            typeValue: typeValue,
-            sender: sender,
-            isFromMe: isFromMe,
-            date: date,
-            resolvedText: resolvedText,
-            messageID: messageID
-          )
-        )
+        matchedRows.append(try decodeReactionRow(row, messageID: messageID))
       }
     }
+    // Preserve nanosecond order before converting timestamps to Foundation Date.
     matchedRows.sort {
-      $0.date == $1.date ? $0.rowID < $1.rowID : $0.date < $1.date
+      $0.timestamp == $1.timestamp ? $0.rowID < $1.rowID : $0.timestamp < $1.timestamp
     }
     for row in matchedRows {
-      var reactions = reactionsByMessageID[row.messageID, default: []]
-      var reactionIndex = reactionIndexByMessageID[row.messageID] ?? [:]
-      applyBulkReactionRow(
-        rowID: row.rowID,
-        typeValue: row.typeValue,
-        sender: row.sender,
-        isFromMe: row.isFromMe,
-        date: row.date,
-        resolvedText: row.resolvedText,
-        messageID: row.messageID,
-        reactions: &reactions,
-        reactionIndex: &reactionIndex
-      )
-      reactionsByMessageID[row.messageID] = reactions
-      reactionIndexByMessageID[row.messageID] = reactionIndex
+      applyReactionRow(row, to: &reactionsByMessageID[row.messageID, default: []])
     }
     return reactionsByMessageID
-  }
-
-  private func baseAssociatedMessageGUID(from associatedGUID: String) -> String {
-    guard let slashIndex = associatedGUID.lastIndex(of: "/") else { return associatedGUID }
-    let guidStart = associatedGUID.index(after: slashIndex)
-    return String(associatedGUID[guidStart...])
-  }
-
-  private func applyBulkReactionRow(
-    rowID: Int64,
-    typeValue: Int,
-    sender: String,
-    isFromMe: Bool,
-    date: Date,
-    resolvedText: String,
-    messageID: Int64,
-    reactions: inout [Reaction],
-    reactionIndex: inout [BulkReactionKey: Int]
-  ) {
-    if ReactionType.isReactionRemove(typeValue) {
-      let customEmoji = typeValue == 3006 ? extractCustomEmoji(from: resolvedText) : nil
-      let reactionType = ReactionType.fromRemoval(typeValue, customEmoji: customEmoji)
-      if let reactionType {
-        let key = BulkReactionKey(sender: sender, isFromMe: isFromMe, reactionType: reactionType)
-        if let index = reactionIndex.removeValue(forKey: key) {
-          reactions.remove(at: index)
-          reactionIndex = BulkReactionKey.reindex(reactions: reactions)
-        }
-        return
-      }
-      if typeValue == 3006 {
-        if let index = reactions.firstIndex(where: {
-          $0.sender == sender && $0.isFromMe == isFromMe && $0.reactionType.isCustom
-        }) {
-          reactions.remove(at: index)
-          reactionIndex = BulkReactionKey.reindex(reactions: reactions)
-        }
-      }
-      return
-    }
-
-    let customEmoji = typeValue == 2006 ? extractCustomEmoji(from: resolvedText) : nil
-    guard let reactionType = ReactionType(rawValue: typeValue, customEmoji: customEmoji) else {
-      return
-    }
-
-    let key = BulkReactionKey(sender: sender, isFromMe: isFromMe, reactionType: reactionType)
-    if let index = reactionIndex[key] {
-      reactions[index] = Reaction(
-        rowID: rowID,
-        reactionType: reactionType,
-        sender: sender,
-        isFromMe: isFromMe,
-        date: date,
-        associatedMessageID: messageID
-      )
-    } else {
-      reactionIndex[key] = reactions.count
-      reactions.append(
-        Reaction(
-          rowID: rowID,
-          reactionType: reactionType,
-          sender: sender,
-          isFromMe: isFromMe,
-          date: date,
-          associatedMessageID: messageID
-        ))
-    }
-  }
-
-  private struct BulkReactionKey: Hashable {
-    let sender: String
-    let isFromMe: Bool
-    let reactionType: ReactionType
-
-    static func reindex(reactions: [Reaction]) -> [BulkReactionKey: Int] {
-      var index: [BulkReactionKey: Int] = [:]
-      for (offset, reaction) in reactions.enumerated() {
-        let key = BulkReactionKey(
-          sender: reaction.sender,
-          isFromMe: reaction.isFromMe,
-          reactionType: reaction.reactionType
-        )
-        index[key] = offset
-      }
-      return index
-    }
-  }
-
-  private struct BulkReactionRow {
-    let rowID: Int64
-    let typeValue: Int
-    let sender: String
-    let isFromMe: Bool
-    let date: Date
-    let resolvedText: String
-    let messageID: Int64
   }
 }

--- a/Sources/IMsgCore/MessageStore+Polls.swift
+++ b/Sources/IMsgCore/MessageStore+Polls.swift
@@ -1,5 +1,25 @@
 import SQLite
 
+private struct PollReferencesQuery {
+  let sql: String
+  let bindings: [Binding?]
+
+  init(guid: String, hasUpdates: Bool) {
+    let updates =
+      hasUpdates
+      ? """
+      UNION SELECT guid FROM message
+      WHERE associated_message_type = ?
+        AND (associated_message_guid = ? COLLATE NOCASE
+          OR associated_message_guid LIKE '%/' || ?)
+      """ : ""
+    sql = "WITH poll_references(guid) AS (SELECT ? \(updates))"
+    bindings =
+      hasUpdates
+      ? [guid, MessagePollDecoder.updateAssociatedMessageType, guid, guid] : [guid]
+  }
+}
+
 extension MessageStore {
   func enrichedPollEvent(
     _ poll: MessagePollEvent?,
@@ -99,37 +119,18 @@ extension MessageStore {
 
   private func decodedPollOptions(guid: String, db: Connection) throws -> [MessagePollOption] {
     let selection = MessageRowSelection(store: self)
-    let sql: String
-    let bindings: [Binding?]
-    if schema.hasReactionColumns {
-      sql = """
-        SELECT \(selection.selectList)
-        FROM message m
-        LEFT JOIN handle h ON m.handle_id = h.ROWID
-        WHERE m.guid = ?
-           OR (
-             m.associated_message_type = ?
-             AND (
-               m.associated_message_guid = ?
-               OR m.associated_message_guid LIKE '%/' || ?
-             )
-           )
-        ORDER BY m.date ASC, m.ROWID ASC
-        """
-      bindings = [guid, MessagePollDecoder.updateAssociatedMessageType, guid, guid]
-    } else {
-      sql = """
-        SELECT \(selection.selectList)
-        FROM message m
-        LEFT JOIN handle h ON m.handle_id = h.ROWID
-        WHERE m.guid = ?
-        ORDER BY m.date ASC, m.ROWID ASC
-        """
-      bindings = [guid]
-    }
+    let source = try sourcePollGUID(forAny: [guid], db: db) ?? guid
+    let references = PollReferencesQuery(guid: source, hasUpdates: schema.hasReactionColumns)
     let rows = try db.prepareRowIterator(
-      sql,
-      bindings: bindings)
+      """
+      \(references.sql)
+      SELECT \(selection.selectList)
+      FROM message m
+      LEFT JOIN handle h ON m.handle_id = h.ROWID
+      WHERE m.guid COLLATE NOCASE IN (SELECT guid FROM poll_references)
+      ORDER BY m.date ASC, m.ROWID ASC
+      """,
+      bindings: references.bindings)
     var options: [MessagePollOption] = []
     var seenIDs = Set<String>()
     while let row = try rows.failableNext() {
@@ -147,22 +148,26 @@ extension MessageStore {
 
   private func latestOutboundPollVoteOptionIDs(guid: String, db: Connection) throws -> [String] {
     guard schema.hasReactionColumns else { return [] }
+    let source = try sourcePollGUID(forAny: [guid], db: db) ?? guid
+    let references = PollReferencesQuery(guid: source, hasUpdates: true)
     let selection = MessageRowSelection(store: self)
     let rows = try db.prepareRowIterator(
       """
+      \(references.sql)
       SELECT \(selection.selectList)
       FROM message m
       LEFT JOIN handle h ON m.handle_id = h.ROWID
       WHERE m.is_from_me = 1
         AND m.associated_message_type = ?
-        AND (
-          m.associated_message_guid = ?
-          OR m.associated_message_guid LIKE '%/' || ?
+        AND EXISTS (
+          SELECT 1 FROM poll_references p
+          WHERE m.associated_message_guid = p.guid COLLATE NOCASE
+            OR m.associated_message_guid LIKE '%/' || p.guid
         )
       ORDER BY m.date DESC, m.ROWID DESC
       LIMIT 1
       """,
-      bindings: [MessagePollDecoder.voteAssociatedMessageType, guid, guid]
+      bindings: references.bindings + [MessagePollDecoder.voteAssociatedMessageType]
     )
     guard let row = try rows.failableNext() else { return [] }
     let decoded = try decodeMessageRow(
@@ -189,7 +194,7 @@ extension MessageStore {
       """
       SELECT associated_message_guid
       FROM message
-      WHERE guid = ?
+      WHERE guid = ? COLLATE NOCASE
         AND associated_message_type = ?
         AND IFNULL(associated_message_guid, '') != ''
       LIMIT 1

--- a/Sources/IMsgCore/MessageStore+Reactions.swift
+++ b/Sources/IMsgCore/MessageStore+Reactions.swift
@@ -12,17 +12,27 @@ private struct CurrentReactionsQuery {
              h.id AS sender, r.is_from_me AS is_from_me, r.date AS date, IFNULL(r.text, '') AS text,
              \(bodyColumn) AS body
       FROM message m
-      JOIN message r ON r.associated_message_guid = m.guid
+      JOIN message r ON r.associated_message_guid = m.guid COLLATE NOCASE
         OR r.associated_message_guid LIKE '%/' || m.guid
       LEFT JOIN handle h ON r.handle_id = h.ROWID
       WHERE m.ROWID = ?
         AND m.guid IS NOT NULL
         AND m.guid != ''
         AND \(reactionPredicate("r.associated_message_type"))
-      ORDER BY r.date ASC
+      ORDER BY r.date ASC, r.ROWID ASC
       """
     self.bindings = [messageID.rawValue]
   }
+}
+
+struct ReactionRow {
+  let rowID: Int64
+  let typeValue: Int
+  let sender: String
+  let isFromMe: Bool
+  let timestamp: Int64
+  let resolvedText: String
+  let messageID: Int64
 }
 
 extension MessageStore {
@@ -34,67 +44,9 @@ extension MessageStore {
     )
     return try withConnection { db in
       var reactions: [Reaction] = []
-      var reactionIndex: [ReactionKey: Int] = [:]
       let rows = try db.prepareRowIterator(query.sql, bindings: query.bindings)
       while let row = try rows.failableNext() {
-        let rowID = try int64Value(row, "reaction_rowid") ?? 0
-        let typeValue = try intValue(row, "associated_message_type") ?? 0
-        let sender = try stringValue(row, "sender")
-        let isFromMe = try boolValue(row, "is_from_me")
-        let date = try appleDate(from: int64Value(row, "date"))
-        let text = try stringValue(row, "text")
-        let body = try dataValue(row, "body")
-        let resolvedText = text.isEmpty ? TypedStreamParser.parseAttributedBody(body) : text
-
-        if ReactionType.isReactionRemove(typeValue) {
-          let customEmoji = typeValue == 3006 ? extractCustomEmoji(from: resolvedText) : nil
-          let reactionType = ReactionType.fromRemoval(typeValue, customEmoji: customEmoji)
-          if let reactionType {
-            let key = ReactionKey(sender: sender, isFromMe: isFromMe, reactionType: reactionType)
-            if let index = reactionIndex.removeValue(forKey: key) {
-              reactions.remove(at: index)
-              reactionIndex = ReactionKey.reindex(reactions: reactions)
-            }
-            continue
-          }
-          if typeValue == 3006 {
-            if let index = reactions.firstIndex(where: {
-              $0.sender == sender && $0.isFromMe == isFromMe && $0.reactionType.isCustom
-            }) {
-              reactions.remove(at: index)
-              reactionIndex = ReactionKey.reindex(reactions: reactions)
-            }
-          }
-          continue
-        }
-
-        let customEmoji: String? = typeValue == 2006 ? extractCustomEmoji(from: resolvedText) : nil
-        guard let reactionType = ReactionType(rawValue: typeValue, customEmoji: customEmoji) else {
-          continue
-        }
-
-        let key = ReactionKey(sender: sender, isFromMe: isFromMe, reactionType: reactionType)
-        if let index = reactionIndex[key] {
-          reactions[index] = Reaction(
-            rowID: rowID,
-            reactionType: reactionType,
-            sender: sender,
-            isFromMe: isFromMe,
-            date: date,
-            associatedMessageID: messageID
-          )
-        } else {
-          reactionIndex[key] = reactions.count
-          reactions.append(
-            Reaction(
-              rowID: rowID,
-              reactionType: reactionType,
-              sender: sender,
-              isFromMe: isFromMe,
-              date: date,
-              associatedMessageID: messageID
-            ))
-        }
+        applyReactionRow(try decodeReactionRow(row, messageID: messageID), to: &reactions)
       }
       return reactions
     }
@@ -123,22 +75,45 @@ extension MessageStore {
     return nil
   }
 
-  private struct ReactionKey: Hashable {
-    let sender: String
-    let isFromMe: Bool
-    let reactionType: ReactionType
+  func decodeReactionRow(_ row: Row, messageID: Int64) throws -> ReactionRow {
+    let text = try stringValue(row, "text")
+    let body = try dataValue(row, "body")
+    return ReactionRow(
+      rowID: try int64Value(row, "reaction_rowid") ?? 0,
+      typeValue: try intValue(row, "associated_message_type") ?? 0,
+      sender: try stringValue(row, "sender"),
+      isFromMe: try boolValue(row, "is_from_me"),
+      timestamp: try int64Value(row, "date") ?? 0,
+      resolvedText: text.isEmpty ? TypedStreamParser.parseAttributedBody(body) : text,
+      messageID: messageID)
+  }
 
-    static func reindex(reactions: [Reaction]) -> [ReactionKey: Int] {
-      var index: [ReactionKey: Int] = [:]
-      for (offset, reaction) in reactions.enumerated() {
-        let key = ReactionKey(
-          sender: reaction.sender,
-          isFromMe: reaction.isFromMe,
-          reactionType: reaction.reactionType
-        )
-        index[key] = offset
-      }
-      return index
+  func applyReactionRow(_ row: ReactionRow, to reactions: inout [Reaction]) {
+    let removal = ReactionType.isReactionRemove(row.typeValue)
+    let emoji =
+      row.typeValue == 2006 || row.typeValue == 3006
+      ? extractCustomEmoji(from: row.resolvedText) : nil
+    let type =
+      removal
+      ? ReactionType.fromRemoval(row.typeValue, customEmoji: emoji)
+      : ReactionType(rawValue: row.typeValue, customEmoji: emoji)
+    let index = reactions.firstIndex {
+      $0.sender == row.sender && $0.isFromMe == row.isFromMe
+        && ($0.reactionType == type
+          || (row.typeValue == 3006 && type == nil && $0.reactionType.isCustom))
+    }
+    if removal {
+      if let index { reactions.remove(at: index) }
+      return
+    }
+    guard let type else { return }
+    let reaction = Reaction(
+      rowID: row.rowID, reactionType: type, sender: row.sender, isFromMe: row.isFromMe,
+      date: appleDate(from: row.timestamp), associatedMessageID: row.messageID)
+    if let index {
+      reactions[index] = reaction
+    } else {
+      reactions.append(reaction)
     }
   }
 }

--- a/Sources/IMsgCore/MessageStore+Sticker.swift
+++ b/Sources/IMsgCore/MessageStore+Sticker.swift
@@ -14,7 +14,7 @@ extension MessageStore {
         FROM message m
         JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
         JOIN chat c ON c.ROWID = cmj.chat_id
-        WHERE m.guid = ?
+        WHERE m.guid = ? COLLATE NOCASE
           AND (c.guid IN (\(placeholders)) OR c.chat_identifier IN (\(placeholders)))
         LIMIT 1
         """,

--- a/Sources/imsg/Commands/PollCaptionStatus.swift
+++ b/Sources/imsg/Commands/PollCaptionStatus.swift
@@ -86,18 +86,13 @@ enum PollCaptionStatus {
     repeat {
       if Task.isCancelled { return .unavailable }
       do {
-        // `messageSendStatus` matches GUIDs COLLATE NOCASE but
-        // `messageBelongsToChat` does not, so hand the membership check the
-        // row's own GUID rather than the bridge's casing. Otherwise a caption
-        // that plainly landed reads back as missing.
-        if let status = try store.messageSendStatus(guid: captionGUID) {
-          let rowGUID = status.guid.isEmpty ? captionGUID : status.guid
-          if try store.messageBelongsToChat(messageGUID: rowGUID, chatGUID: chatGUID) {
-            switch status.state {
-            case .delivered: return .delivered
-            case .failed: return .failed
-            case .pending, .sent: break
-            }
+        if let status = try store.messageSendStatus(guid: captionGUID),
+          try store.messageBelongsToChat(messageGUID: captionGUID, chatGUID: chatGUID)
+        {
+          switch status.state {
+          case .delivered: return .delivered
+          case .failed: return .failed
+          case .pending, .sent: break
           }
         }
       } catch {

--- a/Tests/IMsgCoreTests/MessagePollTests.swift
+++ b/Tests/IMsgCoreTests/MessagePollTests.swift
@@ -660,8 +660,8 @@ func messageStoreDecodesPollVoteRowsWithPayloadGate() throws {
   #expect(streamedUnvote.poll?.votes?.isEmpty ?? true)
 }
 
-@Test
-func messageStoreResolvesVoteOptionTextFromPollUpdateRows() throws {
+@Test(arguments: ["original-poll-guid", "p/original-poll-guid", "p:0/original-poll-guid"])
+func messageStoreResolvesVoteOptionTextFromPollUpdateRows(updateReference: String) throws {
   let db = try Connection(.inMemory)
   var options = MessageDatabaseFixture.SchemaOptions()
   options.includeReactionColumns = true
@@ -700,8 +700,9 @@ func messageStoreResolvesVoteOptionTextFromPollUpdateRows() throws {
       ROWID, handle_id, text, guid, associated_message_guid, associated_message_type,
       balloon_bundle_id, payload_data, message_summary_info, date, is_from_me, service
     )
-    VALUES (1, 1, '', 'updated-poll-guid', 'p/original-poll-guid', 2, ?, ?, NULL, ?, 0, 'iMessage')
+    VALUES (1, 1, '', 'updated-poll-guid', ?, 2, ?, ?, NULL, ?, 0, 'iMessage')
     """,
+    updateReference,
     testPollBundleID,
     updateBlob,
     TestDatabase.appleEpoch(now)
@@ -712,7 +713,7 @@ func messageStoreResolvesVoteOptionTextFromPollUpdateRows() throws {
       ROWID, handle_id, text, guid, associated_message_guid, associated_message_type,
       balloon_bundle_id, payload_data, message_summary_info, date, is_from_me, service
     )
-    VALUES (2, 1, '', 'vote-row-guid', 'p/updated-poll-guid', 4000, NULL, ?, NULL, ?, 0, 'iMessage')
+    VALUES (2, 1, '', 'vote-row-guid', 'p/updated-poll-guid', 4000, NULL, ?, NULL, ?, 1, 'iMessage')
     """,
     voteBlob,
     TestDatabase.appleEpoch(now.addingTimeInterval(1))
@@ -721,6 +722,7 @@ func messageStoreResolvesVoteOptionTextFromPollUpdateRows() throws {
   try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 2)")
 
   let store = try MessageStore(connection: db, path: ":memory:")
+  #expect(try store.pollSelectedOptionIDs(guid: "original-poll-guid") == ["choice-custom"])
   let messages = try store.messagesAfter(afterRowID: 0, chatID: 1, limit: 10)
   let updateMessage = try #require(messages.first { $0.guid == "updated-poll-guid" })
   let voteMessage = try #require(messages.first { $0.guid == "vote-row-guid" })
@@ -903,4 +905,56 @@ private func applePollEnvelopePayload(jsonObject: [String: Any], query: String =
     ],
     requiringSecureCoding: false
   )
+}
+
+@Test
+func pollSnapshotsSpanUpdatesAndKeepLatestEmptyVote() throws {
+  let db = try Connection(.inMemory)
+  var schema = MessageDatabaseFixture.SchemaOptions()
+  schema.includeReactionColumns = true
+  schema.includeBalloonBundleID = true
+  schema.includePayloadData = true
+  try MessageDatabaseFixture.createSchema(db, options: schema)
+  let options: [String: Any] = [
+    "orderedPollOptions": [
+      ["optionIdentifier": "a", "pollOptionText": "A"],
+      ["optionIdentifier": "b", "pollOptionText": "B"],
+    ]
+  ]
+  let payload = Blob(bytes: [UInt8](try applePollEnvelopePayload(jsonObject: options)))
+  for (rowID, guid, reference) in [
+    (10, "update-a", "p/original"), (11, "update-b", "p:0/original"),
+  ] {
+    try db.run(
+      """
+      INSERT INTO message(ROWID, guid, associated_message_guid, associated_message_type, balloon_bundle_id, payload_data, date)
+      VALUES (?, ?, ?, 2, ?, ?, 1)
+      """,
+      rowID, guid, reference, testPollBundleID, payload)
+  }
+  let store = try MessageStore(connection: db, path: ":memory:")
+  func insertVote(_ rowID: Int, _ reference: String, _ selected: [String], mine: Bool = true) throws
+  {
+    let data = try applePollEnvelopePayload(jsonObject: [
+      "votes": selected.map { ["voteOptionIdentifier": $0] }
+    ])
+    try db.run(
+      """
+      INSERT INTO message(ROWID, guid, associated_message_guid, associated_message_type, payload_data, date, is_from_me)
+      VALUES (?, ?, ?, 4000, ?, ?, ?)
+      """,
+      rowID, "vote-\(rowID)", reference, Blob(bytes: [UInt8](data)), rowID, mine ? 1 : 0)
+  }
+  try insertVote(98, "p/unrelated", ["unrelated"])
+  try insertVote(99, "p/update-a", ["inbound"], mine: false)
+  for (rowID, reference, selected) in [
+    (2, "original", ["a"]), (3, "p/update-a", ["a", "b"]),
+    (4, "p:0/update-b", ["b"]), (5, "p/update-a", []),
+  ] {
+    try insertVote(rowID, reference, selected)
+    for guid in ["original", "p:0/update-a", "update-b"] {
+      #expect(try store.pollSelectedOptionIDs(guid: guid) == selected)
+      #expect(try store.pollOptions(guid: guid).map(\.id) == ["a", "b"])
+    }
+  }
 }

--- a/Tests/IMsgCoreTests/MessageStoreReactionsTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreReactionsTests.swift
@@ -78,8 +78,8 @@ private enum ReactionTestDatabase {
   }
 }
 
-@Test
-func reactionsForMessageReturnsReactions() throws {
+@Test(arguments: [false, true])
+func reactionsForMessageReturnsReactions(bulk: Bool) throws {
   let db = try ReactionTestDatabase.makeConnection()
   let now = Date()
   try ReactionTestDatabase.seedBaseMessage(db, now: now)
@@ -118,7 +118,7 @@ func reactionsForMessageReturnsReactions() throws {
   )
 
   let store = try MessageStore(connection: db, path: ":memory:")
-  let reactions = try store.reactions(for: 1)
+  let reactions = try reactionSnapshot(store, bulk: bulk)
 
   #expect(reactions.count == 4)
 
@@ -253,8 +253,8 @@ func reactionsForMessageWithNoReactionsReturnsEmpty() throws {
   #expect(reactions.isEmpty)
 }
 
-@Test
-func reactionsForMessageRemovesReactions() throws {
+@Test(arguments: [false, true])
+func reactionsForMessageRemovesReactions(bulk: Bool) throws {
   let db = try ReactionTestDatabase.makeConnection()
   let now = Date()
   try ReactionTestDatabase.seedBaseMessage(db, now: now)
@@ -275,13 +275,13 @@ func reactionsForMessageRemovesReactions() throws {
   )
 
   let store = try MessageStore(connection: db, path: ":memory:")
-  let reactions = try store.reactions(for: 1)
+  let reactions = try reactionSnapshot(store, bulk: bulk)
 
   #expect(reactions.isEmpty)
 }
 
-@Test
-func reactionsForMessageParsesCustomEmojiWithoutEnglishPrefix() throws {
+@Test(arguments: [false, true])
+func reactionsForMessageParsesCustomEmojiWithoutEnglishPrefix(bulk: Bool) throws {
   let db = try ReactionTestDatabase.makeConnection()
   let now = Date()
   try ReactionTestDatabase.seedBaseMessage(db, now: now)
@@ -295,7 +295,7 @@ func reactionsForMessageParsesCustomEmojiWithoutEnglishPrefix() throws {
   )
 
   let store = try MessageStore(connection: db, path: ":memory:")
-  let reactions = try store.reactions(for: 1)
+  let reactions = try reactionSnapshot(store, bulk: bulk)
 
   #expect(reactions.count == 1)
   #expect(reactions[0].reactionType == .custom("🎉"))
@@ -322,8 +322,8 @@ func reactionsMatchGuidWithoutPrefix() throws {
   #expect(reactions[0].reactionType == .love)
 }
 
-@Test
-func reactionsForMessageRemovesCustomEmojiWithoutEmojiText() throws {
+@Test(arguments: [false, true])
+func reactionsForMessageRemovesCustomEmojiWithoutEmojiText(bulk: Bool) throws {
   let db = try ReactionTestDatabase.makeConnection()
   let now = Date()
   try ReactionTestDatabase.seedBaseMessage(db, now: now)
@@ -344,7 +344,7 @@ func reactionsForMessageRemovesCustomEmojiWithoutEmojiText() throws {
   )
 
   let store = try MessageStore(connection: db, path: ":memory:")
-  let reactions = try store.reactions(for: 1)
+  let reactions = try reactionSnapshot(store, bulk: bulk)
 
   #expect(reactions.isEmpty)
 }
@@ -419,4 +419,34 @@ func reactionTypeHelpers() throws {
   #expect(ReactionType.fromRemoval(3001) == .like)
   #expect(ReactionType.fromRemoval(3005) == .question)
   #expect(ReactionType.fromRemoval(3006, customEmoji: "🎉") == .custom("🎉"))
+}
+
+@Test(arguments: [false, true])
+func reactionSnapshotsRespectDatabaseOrdering(equalDates: Bool) throws {
+  let db = try ReactionTestDatabase.makeConnection()
+  try ReactionTestDatabase.seedBaseMessage(db, now: Date())
+  try db.execute("CREATE INDEX reaction_date_order ON message(date ASC, ROWID DESC)")
+  let date: Int64 = 700_000_000_000_000_000
+  for (rowID, type, timestamp) in [
+    (equalDates ? 2 : 3, 2000, date), (equalDates ? 3 : 2, 3000, equalDates ? date : date + 1),
+  ] {
+    try db.run(
+      """
+      INSERT INTO message(ROWID, handle_id, text, guid, associated_message_guid, associated_message_type, date, is_from_me)
+      VALUES (?, 2, '', ?, 'p:0/msg-guid-1', ?, ?, 0)
+      """,
+      rowID, "reaction-\(rowID)", type, timestamp)
+  }
+  let store = try MessageStore(connection: db, path: ":memory:")
+  #expect(try store.reactions(for: 1).isEmpty)
+  let messages = try store.messages(chatID: 1, limit: 10)
+  #expect(try store.reactions(for: messages)[1]?.isEmpty == true)
+}
+
+private func reactionSnapshot(_ store: MessageStore, bulk: Bool) throws -> [Reaction] {
+  if bulk {
+    let messages = try store.messages(chatID: 1, limit: 10)
+    return try store.reactions(for: messages)[1] ?? []
+  }
+  return try store.reactions(for: 1)
 }

--- a/Tests/IMsgCoreTests/MessageStoreStickerTests.swift
+++ b/Tests/IMsgCoreTests/MessageStoreStickerTests.swift
@@ -3,8 +3,8 @@ import Testing
 
 @testable import IMsgCore
 
-@Test
-func stickerTargetMembershipRequiresTheSelectedChat() throws {
+@Test(arguments: ["anchor-guid", "ANCHOR-GUID"])
+func stickerTargetMembershipRequiresTheSelectedChat(messageGUID: String) throws {
   let db = try Connection(.inMemory)
   try MessageDatabaseFixture.createSchema(
     db,
@@ -33,12 +33,12 @@ func stickerTargetMembershipRequiresTheSelectedChat() throws {
 
   #expect(
     try store.messageBelongsToChat(
-      messageGUID: "anchor-guid",
+      messageGUID: messageGUID,
       chatGUID: "iMessage;-;+111"
     ))
   #expect(
     try !store.messageBelongsToChat(
-      messageGUID: "anchor-guid",
+      messageGUID: messageGUID,
       chatGUID: "iMessage;-;+222"
     ))
   #expect(

--- a/Tests/imsgTests/BridgeRichCommandTests.swift
+++ b/Tests/imsgTests/BridgeRichCommandTests.swift
@@ -529,8 +529,8 @@ func pollCommandVoteResolvesOptionIndex() async throws {
   #expect(result["optionText"] as? String == "No")
 }
 
-@Test
-func pollCommandUnvoteResolvesOptionText() async throws {
+@Test(arguments: [false, true])
+func pollCommandUnvoteResolvesOptionText(updateReference: Bool) async throws {
   let values = ParsedValues(
     positional: ["unvote"],
     options: [
@@ -541,7 +541,8 @@ func pollCommandUnvoteResolvesOptionText() async throws {
     flags: ["jsonOutput"]
   )
   let runtime = RuntimeOptions(parsedValues: values)
-  let store = try CommandTestDatabase.makeStoreForRPCWithOwnPollVoteSnapshot()
+  let store = try CommandTestDatabase.makeStoreForRPCWithOwnPollVoteSnapshot(
+    updateReference: updateReference)
   var capturedAction: BridgeAction?
   var capturedParams: [String: Any] = [:]
 

--- a/Tests/imsgTests/CommandTestDatabase.swift
+++ b/Tests/imsgTests/CommandTestDatabase.swift
@@ -169,10 +169,13 @@ enum CommandTestDatabase {
     )
   }
 
-  static func makeStoreForRPCWithOwnPollVoteSnapshot() throws -> MessageStore {
+  static func makeStoreForRPCWithOwnPollVoteSnapshot(updateReference: Bool = false) throws
+    -> MessageStore
+  {
     try makeStoreForRPCWithPollVoteSnapshot(
       isFromMe: true,
-      selectedOptionIDs: ["choice-yes", "choice-no"]
+      selectedOptionIDs: ["choice-yes", "choice-no"],
+      updateReference: updateReference
     )
   }
 
@@ -193,7 +196,8 @@ enum CommandTestDatabase {
 
   private static func makeStoreForRPCWithPollVoteSnapshot(
     isFromMe: Bool,
-    selectedOptionIDs: [String]
+    selectedOptionIDs: [String],
+    updateReference: Bool = false
   ) throws -> MessageStore {
     let db = try Connection(.inMemory)
     try createSchema(
@@ -248,6 +252,15 @@ enum CommandTestDatabase {
     )
     try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 6)")
     try db.run("INSERT INTO chat_message_join(chat_id, message_id) VALUES (1, 7)")
+    if updateReference {
+      try db.run(
+        """
+        INSERT INTO message(ROWID, guid, associated_message_guid, associated_message_type, date)
+        VALUES (8, 'poll-update', 'p:0/poll-guid-6', 2, ?)
+        """,
+        appleEpoch(now))
+      try db.run("UPDATE message SET associated_message_guid = 'p:0/poll-update' WHERE ROWID = 7")
+    }
     return try MessageStore(connection: db, path: ":memory:")
   }
 

--- a/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
+++ b/Tests/imsgTests/RPCBridgeMessageHandlersTests.swift
@@ -45,9 +45,10 @@ func rpcStatusAdvertisesBridgeMessageMethods() {
   }
 }
 
-@Test
-func rpcPollUnvoteValidatesAndResolvesOption() async throws {
-  let store = try CommandTestDatabase.makeStoreForRPCWithOwnPollVoteSnapshot()
+@Test(arguments: [false, true])
+func rpcPollUnvoteValidatesAndResolvesOption(updateReference: Bool) async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCWithOwnPollVoteSnapshot(
+    updateReference: updateReference)
   let output = TestRPCOutput()
   var capturedAction: BridgeAction?
   var capturedParams: [String: Any] = [:]

--- a/TestsLinux/LinuxReadCoreTests.swift
+++ b/TestsLinux/LinuxReadCoreTests.swift
@@ -191,3 +191,27 @@ func linuxSearchMatchesUnicode(match: String) throws {
   let store = try MessageStore(path: databaseURL.path)
   #expect(try store.searchMessages(query: "café", match: match, limit: 1).map(\.rowID) == [2])
 }
+
+@Test(arguments: [false, true])
+func linuxReactionSnapshotsPreserveDatabaseOrder(equalDates: Bool) throws {
+  let databaseURL = try makeTemporaryDatabase()
+  defer { try? FileManager.default.removeItem(at: databaseURL.deletingLastPathComponent()) }
+  try seedDatabase(at: databaseURL)
+  let db = try Connection(databaseURL.path)
+  try db.run("UPDATE message SET guid = 'target-guid' WHERE ROWID = 1")
+  try db.execute("CREATE INDEX reaction_date_order ON message(date ASC, ROWID DESC)")
+  let date: Int64 = 700_000_000_000_000_000
+  for (rowID, type, timestamp) in [
+    (equalDates ? 10 : 11, 2000, date), (equalDates ? 11 : 10, 3000, equalDates ? date : date + 1),
+  ] {
+    try db.run(
+      """
+      INSERT INTO message(ROWID, handle_id, associated_message_guid, associated_message_type, date, is_from_me)
+      VALUES (?, 1, 'p:0/target-guid', ?, ?, 0)
+      """,
+      rowID, type, timestamp)
+  }
+  let store = try MessageStore(path: databaseURL.path)
+  #expect(try store.reactions(for: 1).isEmpty)
+  #expect(try store.reactions(for: store.messages(chatID: 1, limit: 10))[1]?.isEmpty == true)
+}

--- a/docs/history.md
+++ b/docs/history.md
@@ -63,6 +63,8 @@ Typed-stream decoding preserves Unicode and leading line breaks, including long 
 
 Tapback rows (`Liked "..."`, `Loved "..."`, etc.) are hidden from `history` output by design. They'd otherwise duplicate every reacted message. To see tapbacks, use [`imsg watch --reactions`](watch.md#reactions); the live stream surfaces add and remove events with `is_reaction`, `reaction_type`, and `reacted_to_guid`.
 
+Current reaction snapshots use the same add/remove rules in history and watch. Changes are applied in database timestamp order, then row ID order when timestamps tie.
+
 ## Native polls
 
 Native Apple Messages polls are decoded when Messages stores them as the Polls extension balloon (`com.apple.messages.Polls`). Creation rows include `poll.kind == "created"` with the question and options when available. Native poll payload titles are often empty because Messages shows the question as a separate caption row; imsg backfills an empty created-poll `question` from the earliest clean caption that replies to the poll. Vote update rows include `poll.kind == "vote"` and `poll.original_guid` pointing back to the poll message. Their `poll.votes` array is the participant's full selected-option snapshot, not necessarily the option that changed.
@@ -94,6 +96,8 @@ poll's stable option identifier before sending:
 ```bash
 imsg poll vote --chat-id <id> --poll <poll-guid> --option-index 2
 ```
+
+Option updates remain part of the original poll. Selective unvote reads the newest outbound vote across the original and its update messages, preserving other selected options. An empty newest snapshot means all selections were removed.
 
 On macOS 26.4, use imsg 0.12.2 or later. Earlier builds could create a local
 vote row without the Polls payload, so the recipient's poll did not update.


### PR DESCRIPTION
Poll unvote now reads the latest selection across the original poll and its native option-update messages. Previously history resolved those references, but unvote could reject an existing selection or preserve an older snapshot. Options and outbound votes now share one reference query; a newest empty snapshot remains authoritative, and inbound/unrelated votes do not affect local selections.

History and watch now share one reaction decoder and reducer. Both apply raw database timestamps and row IDs before converting timestamps to `Date`, fixing equal-date and sub-Date-precision ordering disagreements. This removes duplicate index bookkeeping while preserving standard/custom reaction identity and removal behavior. Message membership also matches GUID casing consistently with delivery-status reads, allowing removal of the caption verifier's local workaround.

Validation: 17 baseline regression assertions failed across the affected core, CLI, and RPC paths; the fixed suite passes. The 105 focused tests cover update references, selective unvote, newest empty snapshots, reaction add/remove/custom cases, wrong-chat rejection, and caption delivery. Full `make test` passed 740 Swift tests plus native fixtures/docs checks; lint has 15 existing warnings. Eight Linux tests and the CLI build pass, including tied/nanosecond reaction ordering. Built-CLI history, RPC history, and RPC watch agree in six synthetic database checks. Independent Codex review found no actionable P0–P2 issues.

Production source shrinks by 154 lines. Tests use synthetic databases and injected dispatch; no real messages are sent. The two existing reaction query strategies remain: targeted scalar lookup and one-pass bulk lookup, including reactions joined to a different chat.
