### PR TITLE
fix: verify sends against the resolved delivery route

### DIFF
--- a/Sources/IMsgCore/MessageSender.swift
+++ b/Sources/IMsgCore/MessageSender.swift
@@ -67,6 +67,15 @@ public struct MessageSender {
   }
 
   public func send(_ options: MessageSendOptions) throws {
+    _ = try sendResolvingRoute(options)
+  }
+
+  public func normalizedRecipient(_ recipient: String, region: String) -> String {
+    normalizer.normalize(recipient, region: region.isEmpty ? "US" : region)
+  }
+
+  /// Returns the effective destination after normalization and any safe SMS fallback.
+  public func sendResolvingRoute(_ options: MessageSendOptions) throws -> MessageSendOptions {
     #if !os(macOS)
       _ = options
       throw IMsgError.appleScriptFailure(
@@ -76,9 +85,10 @@ public struct MessageSender {
       let requestedService = resolved.service
       let chatTarget = resolveChatTarget(&resolved)
       let useChat = !chatTarget.isEmpty
+      resolved.recipient = normalizedRecipient(resolved.recipient, region: resolved.region)
       if useChat == false {
-        if resolved.region.isEmpty { resolved.region = "US" }
-        resolved.recipient = normalizer.normalize(resolved.recipient, region: resolved.region)
+        resolved.chatIdentifier = ""
+        resolved.directParticipantTarget = nil
         if resolved.service == .auto { resolved.service = .imessage }
       }
 
@@ -95,7 +105,7 @@ public struct MessageSender {
         && !resolved.text.isEmpty
         && recipientIsPhoneNumber(resolved.recipient)
 
-      try sendViaAppleScript(
+      return try sendViaAppleScript(
         resolved,
         chatTarget: chatTarget,
         useChat: useChat,
@@ -160,7 +170,7 @@ public struct MessageSender {
     chatTarget: String,
     useChat: Bool,
     smsFallbackEligible: Bool
-  ) throws {
+  ) throws -> MessageSendOptions {
     let script = appleScript()
     let directTarget = resolved.directParticipantTarget.flatMap {
       $0.chatGUID == chatTarget ? $0 : nil
@@ -182,13 +192,16 @@ public struct MessageSender {
 
     do {
       try runner(script, arguments(forService: resolved.service))
+      return resolved
     } catch let failure as DeliveryFailure {
       guard smsFallbackEligible, failure.retrySafe else { throw failure }
       try runner(script, arguments(forService: .sms, forceBuddy: true))
-    } catch {
-      // Production runners always emit DeliveryFailure. An injected or future
-      // untyped error has no authoritative dispatch fact and is never retried.
-      throw error
+      var fallback = resolved
+      fallback.service = .sms
+      fallback.chatGUID = ""
+      fallback.chatIdentifier = ""
+      fallback.directParticipantTarget = nil
+      return fallback
     }
   }
 

--- a/Sources/imsg/ChatTargetResolver.swift
+++ b/Sources/imsg/ChatTargetResolver.swift
@@ -108,12 +108,16 @@ enum ChatTargetResolver {
     if includeAnyForSMS, !trimmed.isEmpty {
       candidates = ["SMS;-;\(trimmed)", "any;-;\(trimmed)", "any;+;\(trimmed)"]
     }
+    let services = service == .sms ? ["SMS"] : ["iMessage", "iMessageLite"]
     for candidate in candidates {
       let info =
         includeAnyForSMS
-        ? try store.chatInfo(matchingExactTarget: candidate)
-        : try store.chatInfo(matchingTarget: candidate)
-      if let info { return info }
+        ? try store.chatInfo(matchingExactTarget: candidate, preferredServices: services)
+        : try store.chatInfo(matchingTarget: candidate, preferredServices: services)
+      // Auto-detected SMS can use a neutral "any" chat with older service metadata.
+      if let info, includeAnyForSMS || service == .auto || services.contains(info.service) {
+        return info
+      }
     }
     return nil
   }

--- a/Sources/imsg/CommandRouter.swift
+++ b/Sources/imsg/CommandRouter.swift
@@ -81,32 +81,35 @@ struct CommandRouter {
       guard let commandName = invocation.path.last,
         let spec = specs.first(where: { $0.name == commandName })
       else {
-        StdoutWriter.writeLine("Unknown command")
-        HelpPrinter.printRoot(version: version, rootName: rootName, commands: specs)
+        writeDiagnostic("Unknown command")
+        writeDiagnostic(
+          HelpPrinter.renderRoot(version: version, rootName: rootName, commands: specs).joined(
+            separator: "\n"))
         return 1
       }
       let runtime = RuntimeOptions(parsedValues: invocation.parsedValues)
-      do {
-        try await spec.run(invocation.parsedValues, runtime)
-        return 0
-      } catch is BridgeOutput.EmittedError {
-        return 1
-      } catch is CommandOutputEmittedError {
-        return 1
-      } catch {
-        StdoutWriter.writeLine(String(describing: error))
-        return 1
-      }
+      try await spec.run(invocation.parsedValues, runtime)
+      return 0
+    } catch is BridgeOutput.EmittedError {
+      return 1
+    } catch is CommandOutputEmittedError {
+      return 1
     } catch let error as CommanderProgramError {
-      StdoutWriter.writeLine(error.description)
+      writeDiagnostic(error.description)
       if case .missingSubcommand = error {
-        HelpPrinter.printRoot(version: version, rootName: rootName, commands: specs)
+        writeDiagnostic(
+          HelpPrinter.renderRoot(version: version, rootName: rootName, commands: specs).joined(
+            separator: "\n"))
       }
       return 1
     } catch {
-      StdoutWriter.writeLine(String(describing: error))
+      writeDiagnostic(String(describing: error))
       return 1
     }
+  }
+
+  private func writeDiagnostic(_ message: String) {
+    FileHandle.standardError.write(Data((message + "\n").utf8))
   }
 
   private func normalizeArguments(_ argv: [String]) -> [String] {

--- a/Sources/imsg/Commands/SendCommand.swift
+++ b/Sources/imsg/Commands/SendCommand.swift
@@ -43,7 +43,9 @@ enum SendCommand {
   static func run(
     values: ParsedValues,
     runtime: RuntimeOptions,
-    sendMessage: @escaping (MessageSendOptions) throws -> Void = { try MessageSender().send($0) },
+    sendMessage: @escaping (MessageSendOptions) throws -> MessageSendOptions = {
+      try MessageSender().sendResolvingRoute($0)
+    },
     resolveSentMessage:
       @escaping (
         MessageStore,
@@ -73,13 +75,16 @@ enum SendCommand {
       mixedTargetError: ParsedValuesError.invalidOption("to"),
       missingRecipientError: ParsedValuesError.missingOption("to")
     )
-    let recipient: String
+    let resolvedRecipient: String
     if !rawInput.hasChatTarget && ChatTargetResolver.looksLikeContactName(rawRecipient) {
       let contacts = await contactResolverFactory(region)
-      recipient = try ChatTargetResolver.resolveRecipientName(rawRecipient, contacts: contacts)
+      resolvedRecipient = try ChatTargetResolver.resolveRecipientName(
+        rawRecipient, contacts: contacts)
     } else {
-      recipient = rawRecipient
+      resolvedRecipient = rawRecipient
     }
+
+    let recipient = MessageSender().normalizedRecipient(resolvedRecipient, region: region)
 
     let input = ChatTargetInput(
       recipient: recipient,
@@ -165,19 +170,15 @@ enum SendCommand {
         store: store, resolvedTarget: resolvedTarget, directChatInfo: directChatInfo)
     )
     let sentAt = Date()
-    try sendMessage(options)
+    let sentOptions = try sendMessage(options)
 
     var sentMessage: Message?
     if let store, input.hasChatTarget || !text.isEmpty {
-      let verificationChatID =
-        input.chatID
-        ?? (input.hasChatTarget ? resolvedTarget.preferredIdentifier : nil).flatMap {
-          try? store.chatInfo(matchingTarget: $0)?.id
-        }
-        ?? directChatInfo?.id
+      let verificationChatID = try? SentMessageVerifier.verificationChatID(
+        store: store, options: sentOptions)
       sentMessage = try await SentMessageVerifier.verifyAppleScriptSend(
         store: store,
-        options: options,
+        options: sentOptions,
         chatID: verificationChatID,
         sentAt: sentAt,
         resolve: resolveSentMessage

--- a/Sources/imsg/RPCServer+Handlers.swift
+++ b/Sources/imsg/RPCServer+Handlers.swift
@@ -168,15 +168,16 @@ extension RPCServer {
     ).flatMap { $0.isEmpty ? nil : $0 }
     let rawInput = try params.recipientOrChatTarget()
     let rawRecipient = rawInput.recipient
-    let recipient: String
+    let resolvedRecipient: String
     do {
-      recipient =
+      resolvedRecipient =
         rawInput.hasChatTarget || rawRecipient.isEmpty
         ? rawRecipient
         : try ChatTargetResolver.resolveRecipientName(rawRecipient, contacts: requestContacts)
     } catch {
       throw RPCError.invalidParams(error.localizedDescription)
     }
+    let recipient = MessageSender().normalizedRecipient(resolvedRecipient, region: region)
     let input = ChatTargetInput(
       recipient: recipient,
       chatID: rawInput.chatID,
@@ -317,19 +318,17 @@ extension RPCServer {
       )
     }
 
-    try sendMessage(options)
+    let sentOptions = try sendMessage(options)
 
     let sentMessage: Message?
     let verificationChatID =
-      input.chatID
-      ?? resolvedTarget.preferredIdentifier.flatMap {
-        try? database?.store.chatInfo(matchingTarget: $0)?.id
+      database.flatMap {
+        try? SentMessageVerifier.verificationChatID(store: $0.store, options: sentOptions)
       }
-      ?? directChatInfo?.id
     if let database, input.hasChatTarget || !text.isEmpty {
       sentMessage = try await SentMessageVerifier.verifyAppleScriptSend(
         store: database.store,
-        options: options,
+        options: sentOptions,
         chatID: verificationChatID,
         sentAt: sentAt,
         resolve: resolveSentMessage
@@ -345,35 +344,20 @@ extension RPCServer {
         result["message_id"] = sentMessage.guid
       }
     }
-    var responseChatInfo: ChatInfo?
-    if let sentMessage, let database {
-      responseChatInfo = try? database.store.chatInfo(chatID: sentMessage.chatID)
-    }
-    if responseChatInfo == nil, let verificationChatID, let database {
-      responseChatInfo = try? database.store.chatInfo(chatID: verificationChatID)
-    }
-    if responseChatInfo == nil {
-      responseChatInfo = directChatInfo
-    }
-    if let chatInfo = responseChatInfo {
-      if !chatInfo.guid.isEmpty {
-        result["chat_guid"] = chatInfo.guid
-      }
-      if !chatInfo.service.isEmpty {
+    if let sentMessage, !sentMessage.service.isEmpty { result["service"] = sentMessage.service }
+    if let chatID = sentMessage?.chatID ?? verificationChatID,
+      let chatInfo = try? database?.store.chatInfo(chatID: chatID)
+    {
+      if !chatInfo.guid.isEmpty { result["chat_guid"] = chatInfo.guid }
+      if result["service"] == nil && !chatInfo.service.isEmpty {
         result["service"] = chatInfo.service
       }
     }
-    if result["chat_guid"] == nil {
-      let resolvedChatGUID =
-        !resolvedTarget.chatGUID.isEmpty ? resolvedTarget.chatGUID : (directChatInfo?.guid ?? "")
-      if !resolvedChatGUID.isEmpty {
-        result["chat_guid"] = resolvedChatGUID
-      }
+    if result["chat_guid"] == nil && !sentOptions.chatGUID.isEmpty {
+      result["chat_guid"] = sentOptions.chatGUID
     }
-    if result["service"] == nil,
-      let directService = directChatInfo?.service, !directService.isEmpty
-    {
-      result["service"] = directService
+    if result["service"] == nil && sentOptions.service != .auto {
+      result["service"] = sentOptions.service == .sms ? "SMS" : "iMessage"
     }
     respond(id: id, result: result)
   }

--- a/Sources/imsg/RPCServer.swift
+++ b/Sources/imsg/RPCServer.swift
@@ -52,7 +52,7 @@ final class RPCServer: @unchecked Sendable {
   let output: RPCOutput
   let subscriptions: SubscriptionStore
   let verbose: Bool
-  let sendMessage: (MessageSendOptions) throws -> Void
+  let sendMessage: (MessageSendOptions) throws -> MessageSendOptions
   let resolveSentMessage: SentMessageResolver
   let bridgeInvoker: BridgeInvoker
   let captionVerifier: CaptionVerifier
@@ -79,7 +79,9 @@ final class RPCServer: @unchecked Sendable {
     store: MessageStore,
     verbose: Bool,
     output: RPCOutput = RPCWriter(),
-    sendMessage: @escaping (MessageSendOptions) throws -> Void = { try MessageSender().send($0) },
+    sendMessage: @escaping (MessageSendOptions) throws -> MessageSendOptions = {
+      try MessageSender().sendResolvingRoute($0)
+    },
     resolveSentMessage: @escaping SentMessageResolver = RPCServer.resolveSentMessage,
     invokeBridge: @escaping BridgeInvoker = { action, params in
       try await IMsgBridgeClient.shared.invokeWithoutLaunching(action: action, params: params)
@@ -149,7 +151,9 @@ final class RPCServer: @unchecked Sendable {
     verbose: Bool,
     output: RPCOutput = RPCWriter(),
     storeFactory: @escaping RPCMessageStoreFactory = { try MessageStore(path: $0) },
-    sendMessage: @escaping (MessageSendOptions) throws -> Void = { try MessageSender().send($0) },
+    sendMessage: @escaping (MessageSendOptions) throws -> MessageSendOptions = {
+      try MessageSender().sendResolvingRoute($0)
+    },
     resolveSentMessage: @escaping SentMessageResolver = RPCServer.resolveSentMessage,
     invokeBridge: @escaping BridgeInvoker = { action, params in
       try await IMsgBridgeClient.shared.invokeWithoutLaunching(action: action, params: params)

--- a/Sources/imsg/SentMessageVerifier.swift
+++ b/Sources/imsg/SentMessageVerifier.swift
@@ -73,18 +73,7 @@ enum SentMessageVerifier {
     chatID: Int64?,
     since date: Date
   ) throws -> Message? {
-    let verificationChatID: Int64?
-    if let chatID {
-      verificationChatID = chatID
-    } else if !options.recipient.isEmpty {
-      verificationChatID = try ChatTargetResolver.existingDirectChat(
-        store: store,
-        recipient: options.recipient,
-        service: options.service
-      )?.id
-    } else {
-      verificationChatID = nil
-    }
+    let verificationChatID = try chatID ?? self.verificationChatID(store: store, options: options)
     guard let verificationChatID else { return nil }
 
     return try store.latestSentMessage(
@@ -92,6 +81,14 @@ enum SentMessageVerifier {
       chatID: verificationChatID,
       since: date
     )
+  }
+
+  static func verificationChatID(store: MessageStore, options: MessageSendOptions) throws -> Int64?
+  {
+    let target = options.chatGUID.isEmpty ? options.chatIdentifier : options.chatGUID
+    if !target.isEmpty { return try store.chatInfo(matchingTarget: target)?.id }
+    return try ChatTargetResolver.existingDirectChat(
+      store: store, recipient: options.recipient, service: options.service)?.id
   }
 
   static func throwIfMisroutedChatSend(
@@ -103,7 +100,7 @@ enum SentMessageVerifier {
     guard !handles.isEmpty else { return }
     let lowerBound = sentAt.addingTimeInterval(-2)
     guard
-      let rowID = try store.latestUnjoinedSentMessageRowID(
+      let rowID = try? store.latestUnjoinedSentMessageRowID(
         matchingTargetHandles: handles,
         since: lowerBound
       )

--- a/Tests/IMsgCoreTests/MessageSenderSMSFallbackTests.swift
+++ b/Tests/IMsgCoreTests/MessageSenderSMSFallbackTests.swift
@@ -7,6 +7,7 @@ import Testing
   private final class RunnerSpy: @unchecked Sendable {
     private(set) var services: [String] = []
     private(set) var useChatFlags: [String] = []
+    private(set) var recipients: [String] = []
     var firstFailure: DeliveryDisposition?
 
     func run(_ source: String, _ arguments: [String]) throws {
@@ -14,6 +15,7 @@ import Testing
       let service = arguments[2]
       services.append(service)
       useChatFlags.append(arguments[6])
+      recipients.append(arguments[0])
       if let firstFailure, services.count == 1 {
         throw DeliveryFailure(
           disposition: firstFailure,
@@ -47,18 +49,24 @@ import Testing
     spy.firstFailure = .notStarted
     let sender = MessageSender(runner: spy.run)
 
-    try sender.send(
+    let route = try sender.sendResolvingRoute(
       MessageSendOptions(
-        recipient: "+15551234567",
+        recipient: "07700 900000",
         text: "hi",
         service: .auto,
-        chatGUID: "any;-;+15551234567",
+        region: "GB",
+        chatGUID: "any;-;+447700900000",
         allowSMSFallback: true
       )
     )
 
     #expect(spy.services == ["auto", "sms"])
     #expect(spy.useChatFlags == ["1", "0"])
+    #expect(spy.recipients == ["+447700900000", "+447700900000"])
+    #expect(route.recipient == "+447700900000")
+    #expect(route.service == .sms)
+    #expect(route.chatGUID.isEmpty && route.chatIdentifier.isEmpty)
+    #expect(route.directParticipantTarget == nil)
   }
 
   @Test

--- a/Tests/imsgTests/AppleScriptSendVerificationTests.swift
+++ b/Tests/imsgTests/AppleScriptSendVerificationTests.swift
@@ -6,10 +6,12 @@ import Testing
 @testable import IMsgCore
 @testable import imsg
 
-@Test
-func rpcForcedAppleScriptUsesExistingDirectChatAndVerifiesText() async throws {
+@Test(arguments: [false, true])
+func rpcForcedAppleScriptUsesExistingDirectChatAndVerifiesText(localFormat: Bool) async throws {
   let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
-  try setAnyDirectChat(store)
+  let canonical = localFormat ? "+447700900000" : "+123"
+  let recipient = localFormat ? "07700 900000" : "+123"
+  try setAnyDirectChat(store, recipient: canonical)
   let output = TestRPCOutput()
   var captured: MessageSendOptions?
   var verifiedChatID: Int64?
@@ -17,7 +19,10 @@ func rpcForcedAppleScriptUsesExistingDirectChatAndVerifiesText() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { captured = $0 },
+    sendMessage: {
+      captured = $0
+      return $0
+    },
     resolveSentMessage: { _, options, chatID, _ in
       verifiedChatID = chatID
       return sentMessage(options: options, chatID: chatID)
@@ -25,12 +30,16 @@ func rpcForcedAppleScriptUsesExistingDirectChatAndVerifiesText() async throws {
   )
 
   await server.handleLineForTesting(
-    #"{"jsonrpc":"2.0","id":"direct","method":"send","params":{"to":"+123","text":"nonce","service":"imessage","transport":"applescript"}}"#
+    #"""
+    {"jsonrpc":"2.0","id":"direct","method":"send",
+    "params":{"to":"+123","text":"nonce","service":"imessage","transport":"applescript","region":"GB"}}
+    """#
+    .replacingOccurrences(of: "+123", with: recipient)
   )
 
-  #expect(captured?.recipient == "+123")
+  #expect(captured?.recipient == canonical)
   #expect(captured?.chatIdentifier.isEmpty == true)
-  #expect(captured?.chatGUID == "any;-;+123")
+  #expect(captured?.chatGUID == "any;-;\(canonical)")
   #expect(captured?.service == .imessage)
   #expect(verifiedChatID == 1)
   let result = output.responses.first?["result"] as? [String: Any]
@@ -38,16 +47,21 @@ func rpcForcedAppleScriptUsesExistingDirectChatAndVerifiesText() async throws {
   #expect(result?["guid"] as? String == "verified-guid")
 }
 
-@Test
-func sendCommandUsesExistingDirectChatAndVerifiesText() async throws {
+@Test(arguments: [false, true])
+func sendCommandUsesExistingDirectChatAndVerifiesText(localFormat: Bool) async throws {
+  let canonical = localFormat ? "+447700900000" : "+123"
+  let recipient = localFormat ? "07700 900000" : "+123"
   let path = try CommandTestDatabase.makePathDirectChat()
   let db = try Connection(path)
-  try db.run("UPDATE chat SET guid = 'any;-;+123', service_name = 'iMessage' WHERE ROWID = 1")
+  try db.run(
+    "UPDATE chat SET guid = ?, chat_identifier = ?, service_name = 'iMessage' WHERE ROWID = 1",
+    "any;-;\(canonical)", canonical)
   let values = ParsedValues(
     positional: [],
     options: [
       "db": [path],
-      "to": ["+123"],
+      "to": [recipient],
+      "region": ["GB"],
       "text": ["nonce"],
       "service": ["imessage"],
     ],
@@ -61,7 +75,10 @@ func sendCommandUsesExistingDirectChatAndVerifiesText() async throws {
     try await SendCommand.run(
       values: values,
       runtime: runtime,
-      sendMessage: { captured = $0 },
+      sendMessage: {
+        captured = $0
+        return $0
+      },
       resolveSentMessage: { _, options, chatID, _ in
         verifiedChatID = chatID
         return sentMessage(options: options, chatID: chatID)
@@ -69,9 +86,9 @@ func sendCommandUsesExistingDirectChatAndVerifiesText() async throws {
     )
   }
 
-  #expect(captured?.recipient == "+123")
+  #expect(captured?.recipient == canonical)
   #expect(captured?.chatIdentifier.isEmpty == true)
-  #expect(captured?.chatGUID == "any;-;+123")
+  #expect(captured?.chatGUID == "any;-;\(canonical)")
   #expect(captured?.service == .imessage)
   #expect(verifiedChatID == 1)
 }
@@ -134,15 +151,21 @@ func newRecipientVerificationIgnoresUnrelatedSameTextSend() throws {
   #expect(intended?.chatID == 2)
 }
 
-@Test
-func rpcAppleScriptSuccessWithoutTextRowReturnsOutcomeUnknown() async throws {
+@Test(arguments: [false, true])
+func rpcAppleScriptSuccessWithoutTextRowReturnsOutcomeUnknown(databaseUnreadable: Bool) async throws
+{
   let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
   let output = TestRPCOutput()
   let server = RPCServer(
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in },
+    sendMessage: { options in
+      if databaseUnreadable {
+        try store.withConnection { try $0.execute("DROP TABLE message") }
+      }
+      return options
+    },
     resolveSentMessage: { _, _, _, _ in nil }
   )
 
@@ -176,7 +199,7 @@ func sendCommandSuccessWithoutTextRowThrowsTypedUncertainty() async throws {
     try await SendCommand.run(
       values: values,
       runtime: runtime,
-      sendMessage: { _ in },
+      sendMessage: { $0 },
       resolveSentMessage: { _, _, _, _ in nil }
     )
     Issue.record("expected unconfirmed delivery failure")
@@ -200,7 +223,7 @@ func directChatGhostKeepsExistingDiagnosticAheadOfNoRowUncertainty() async throw
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in
+    sendMessage: { options in
       try store.withConnection { db in
         try db.run("INSERT INTO handle(ROWID, id) VALUES (99, 'any;-;+123')")
         try db.run(
@@ -211,6 +234,7 @@ func directChatGhostKeepsExistingDiagnosticAheadOfNoRowUncertainty() async throw
           CommandTestDatabase.appleEpoch(Date())
         )
       }
+      return options
     },
     resolveSentMessage: { _, _, _, _ in nil }
   )
@@ -229,10 +253,11 @@ func directChatGhostKeepsExistingDiagnosticAheadOfNoRowUncertainty() async throw
   #expect((data?["detail"] as? String)?.contains("unjoined empty outgoing row (99)") == true)
 }
 
-private func setAnyDirectChat(_ store: MessageStore) throws {
+private func setAnyDirectChat(_ store: MessageStore, recipient: String = "+123") throws {
   _ = try store.withConnection { db in
     try db.run(
-      "UPDATE chat SET chat_identifier = '+123', guid = 'any;-;+123', service_name = 'iMessage' WHERE ROWID = 1"
+      "UPDATE chat SET chat_identifier = ?, guid = ?, service_name = 'iMessage' WHERE ROWID = 1",
+      recipient, "any;-;\(recipient)"
     )
   }
 }
@@ -250,4 +275,73 @@ private func sentMessage(options: MessageSendOptions, chatID: Int64?) -> Message
     attachmentsCount: 0,
     guid: "verified-guid"
   )
+}
+
+@Test(arguments: [MessageService.sms, .imessage])
+func directChatSelectionHonorsExplicitService(service: MessageService) throws {
+  let store = try CommandTestDatabase.makeStoreForRPCDirectChat()
+  let opposite = service == .sms ? "iMessage" : "SMS"
+  _ = try store.withConnection { db in
+    try db.run(
+      "UPDATE chat SET guid = ?, service_name = ? WHERE ROWID = 1", "\(opposite);-;+123", opposite)
+  }
+  #expect(
+    try ChatTargetResolver.existingDirectChat(store: store, recipient: "+123", service: service)
+      == nil)
+}
+
+@Test(arguments: [false, true])
+func sendVerificationFollowsActualSMSFallback(rpc: Bool) async throws {
+  let store = try CommandTestDatabase.makeStoreForRPCWithStickerTarget()
+  try setAnyDirectChat(store)
+  var attempts = 0
+  let sender = MessageSender(runner: { _, arguments in
+    attempts += 1
+    if attempts == 1 {
+      throw DeliveryFailure(
+        disposition: .notStarted, transport: .appleScript,
+        operation: "send", detail: "synthetic first-attempt failure")
+    }
+    #expect(arguments[2] == "sms")
+    #expect(arguments[6] == "0")
+    try store.withConnection { db in
+      try db.run(
+        "INSERT INTO chat(ROWID, chat_identifier, guid, service_name) VALUES (2, '+123', 'SMS;-;+123', 'SMS')"
+      )
+      for (rowID, chatID, service) in [(90, 1, "iMessage"), (91, 2, "SMS")] {
+        try db.run(
+          """
+          INSERT INTO message(ROWID, handle_id, text, guid, date, is_from_me, service)
+          VALUES (?, 1, 'fallback nonce', ?, ?, 1, ?)
+          """,
+          rowID, "sent-\(rowID)", CommandTestDatabase.appleEpoch(Date()), service)
+        try db.run(
+          "INSERT INTO chat_message_join(chat_id, message_id) VALUES (?, ?)", chatID, rowID)
+      }
+    }
+  })
+  let result: [String: Any]
+  if rpc {
+    let output = TestRPCOutput()
+    let server = RPCServer(
+      store: store, verbose: false, output: output, sendMessage: sender.sendResolvingRoute)
+    await server.handleLineForTesting(
+      #"{"jsonrpc":"2.0","id":1,"method":"send","params":{"to":"+123","text":"fallback nonce","transport":"applescript"}}"#
+    )
+    result = try #require(output.responses.first?["result"] as? [String: Any])
+    #expect(result["service"] as? String == "SMS")
+    #expect(result["chat_guid"] as? String == "SMS;-;+123")
+  } else {
+    let values = ParsedValues(
+      positional: [], options: ["to": ["+123"], "text": ["fallback nonce"]], flags: ["jsonOutput"])
+    let (output, _) = try await StdoutCapture.capture {
+      try await SendCommand.run(
+        values: values, runtime: RuntimeOptions(parsedValues: values),
+        sendMessage: sender.sendResolvingRoute, storeFactory: { _ in store })
+    }
+    result = try #require(JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any])
+  }
+  #expect(attempts == 2)
+  #expect(result["id"] as? Int64 == 91)
+  #expect(result["guid"] as? String == "sent-91")
 }

--- a/Tests/imsgTests/BridgeCommandRegistrationTests.swift
+++ b/Tests/imsgTests/BridgeCommandRegistrationTests.swift
@@ -42,12 +42,11 @@ func injectedHelperReportsAuthoritativeMultipartCapability() throws {
 }
 
 @Test
-func bridgeMessagingCommandsExposeChatRequirement() async {
+func bridgeMessagingCommandsExposeChatRequirement() throws {
   // Each new bridge messaging command requires a `--chat` option (the chat
   // guid is the universal addressing key in v2). Ensure missing args bubble
   // up as a parse-time error rather than dropping into the bridge with empty
   // strings.
-  let router = CommandRouter()
   let cases: [(name: String, args: [String])] = [
     ("send-rich", ["--text", "hello"]),
     ("poll", ["send", "--question", "Dinner?", "--option", "A", "--option", "B"]),
@@ -58,11 +57,10 @@ func bridgeMessagingCommandsExposeChatRequirement() async {
     ("send-sticker", ["--file", "~/Desktop/sticker.png"]),
   ]
   for testCase in cases {
-    let (output, status) = await StdoutCapture.capture {
-      await router.run(argv: ["imsg", testCase.name] + testCase.args)
-    }
-    #expect(status == 1, "\(testCase.name) should require --chat")
-    #expect(output.contains("Missing required option: --chat"))
+    let result = try runIMsgProcess([testCase.name] + testCase.args)
+    #expect(result.status == 1, "\(testCase.name) should require --chat")
+    #expect(result.output.isEmpty)
+    #expect(result.error.contains("Missing required option: --chat"))
   }
 }
 
@@ -496,15 +494,13 @@ private func functionBody(named name: String, in source: String) -> String? {
 }
 
 @Test
-func chatMarkRejectsConflictingFlags() async {
-  let router = CommandRouter()
-  let (output, status) = await StdoutCapture.capture {
-    await router.run(argv: [
-      "imsg", "chat-mark", "--chat", "iMessage;-;+15551234567", "--read", "--unread",
-    ])
-  }
-  #expect(status == 1)
-  #expect(output.contains("Invalid value for option: --read"))
+func chatMarkRejectsConflictingFlags() throws {
+  let result = try runIMsgProcess([
+    "chat-mark", "--chat", "iMessage;-;+15551234567", "--read", "--unread",
+  ])
+  #expect(result.status == 1)
+  #expect(result.output.isEmpty)
+  #expect(result.error.contains("Invalid value for option: --read"))
 }
 
 @Test

--- a/Tests/imsgTests/CLIOptionValidationTests.swift
+++ b/Tests/imsgTests/CLIOptionValidationTests.swift
@@ -8,7 +8,7 @@ import Testing
 private enum ValidationTestError: Error { case workStarted }
 
 @Test(arguments: ["not-a-number", "9223372036854775808", "", "0"])
-func numericReadOptionsRejectInvalidValuesBeforeOpeningDatabase(raw: String) async {
+func numericReadOptionsRejectInvalidValuesBeforeOpeningDatabase(raw: String) throws {
   let cases: [(arguments: [String], option: String)] = [
     (["chats", "--limit", raw], "limit"),
     (["history", "--chat-id", raw], "chat-id"),
@@ -21,12 +21,11 @@ func numericReadOptionsRejectInvalidValuesBeforeOpeningDatabase(raw: String) asy
     (["scheduled", "list", "--limit", raw], "limit"),
   ]
   for testCase in cases where raw != "0" || testCase.option != "since-rowid" {
-    let (output, status) = await StdoutCapture.capture {
-      await CommandRouter().run(
-        argv: ["imsg"] + testCase.arguments + ["--db", "/nonexistent/imsg-validation.db"])
-    }
-    #expect(status == 1)
-    #expect(output.contains("Invalid value for option: --\(testCase.option)"))
+    let result = try runIMsgProcess(
+      testCase.arguments + ["--db", "/nonexistent/imsg-validation.db"])
+    #expect(result.status == 1)
+    #expect(result.output.isEmpty)
+    #expect(result.error.contains("Invalid value for option: --\(testCase.option)"))
   }
 }
 
@@ -47,7 +46,11 @@ func malformedChatIDCannotFallBackToRecipient(command: String) async throws {
     switch command {
     case "send":
       try await SendCommand.run(
-        values: values, runtime: runtime, sendMessage: { _ in didWork = true },
+        values: values, runtime: runtime,
+        sendMessage: { options in
+          didWork = true
+          return options
+        },
         storeFactory: store)
     case "read":
       try await ReadCommand.run(

--- a/Tests/imsgTests/ChatHistorySendCommandTests.swift
+++ b/Tests/imsgTests/ChatHistorySendCommandTests.swift
@@ -280,7 +280,10 @@ func sendCommandResolvesUniqueContactName() async throws {
     try await SendCommand.run(
       values: values,
       runtime: runtime,
-      sendMessage: { options in captured = options },
+      sendMessage: { options in
+        captured = options
+        return options
+      },
       resolveSentMessage: resolvedSentMessageFixture,
       storeFactory: { _ in try CommandTestDatabase.makeStoreForRPC() },
       contactResolverFactory: { _ in resolver }
@@ -307,7 +310,7 @@ func sendCommandRejectsAmbiguousContactName() async {
     try await SendCommand.run(
       values: values,
       runtime: runtime,
-      sendMessage: { _ in },
+      sendMessage: { $0 },
       resolveSentMessage: { _, _, _, _ in nil },
       contactResolverFactory: { _ in resolver }
     )
@@ -334,6 +337,7 @@ func sendCommandRunsWithStubSender() async throws {
       runtime: runtime,
       sendMessage: { options in
         captured = options
+        return options
       },
       resolveSentMessage: resolvedSentMessageFixture,
       storeFactory: { _ in try CommandTestDatabase.makeStoreForRPC() }
@@ -359,6 +363,7 @@ func sendCommandResolvesChatID() async throws {
       runtime: runtime,
       sendMessage: { options in
         captured = options
+        return options
       },
       resolveSentMessage: resolvedSentMessageFixture
     )
@@ -382,7 +387,7 @@ func sendCommandJsonIncludesResolvedMessageGuidForChatTarget() async throws {
     try await SendCommand.run(
       values: values,
       runtime: runtime,
-      sendMessage: { _ in },
+      sendMessage: { $0 },
       resolveSentMessage: { _, options, chatID, _ in
         Message(
           rowID: 42,
@@ -421,7 +426,7 @@ func sendCommandRejectsMisroutedChatGhost() async throws {
     try await SendCommand.run(
       values: values,
       runtime: runtime,
-      sendMessage: { _ in
+      sendMessage: { options in
         let db = try Connection(path)
         try db.run("INSERT INTO handle(ROWID, id) VALUES (99, 'iMessage;+;chat123')")
         try db.run(
@@ -431,6 +436,7 @@ func sendCommandRejectsMisroutedChatGhost() async throws {
           """,
           CommandTestDatabase.appleEpoch(Date())
         )
+        return options
       },
       resolveSentMessage: { _, _, _, _ in nil }
     )
@@ -458,7 +464,10 @@ func sendCommandAutoResolvesToSMSWhenDetected() async throws {
     try await SendCommand.run(
       values: values,
       runtime: runtime,
-      sendMessage: { options in captured = options },
+      sendMessage: { options in
+        captured = options
+        return options
+      },
       resolveSentMessage: resolvedSentMessageFixture,
       storeFactory: { _ in try CommandTestDatabase.makeStoreForRPC() },
       resolveService: { _, _, _ in .sms }
@@ -480,7 +489,10 @@ func sendCommandAutoResolvesUnknownToIMessage() async throws {
     try await SendCommand.run(
       values: values,
       runtime: runtime,
-      sendMessage: { options in captured = options },
+      sendMessage: { options in
+        captured = options
+        return options
+      },
       resolveSentMessage: resolvedSentMessageFixture,
       storeFactory: { _ in try CommandTestDatabase.makeStoreForRPC() },
       resolveService: { _, _, _ in .unknown }
@@ -503,7 +515,10 @@ func sendCommandHonorsNoSMSFallbackFlag() async throws {
     try await SendCommand.run(
       values: values,
       runtime: runtime,
-      sendMessage: { options in captured = options },
+      sendMessage: { options in
+        captured = options
+        return options
+      },
       resolveSentMessage: resolvedSentMessageFixture,
       storeFactory: { _ in try CommandTestDatabase.makeStoreForRPC() },
       resolveService: { _, _, _ in .imessage }
@@ -525,7 +540,10 @@ func sendCommandDisablesSMSFallbackForAttachments() async throws {
     try await SendCommand.run(
       values: values,
       runtime: runtime,
-      sendMessage: { options in captured = options },
+      sendMessage: { options in
+        captured = options
+        return options
+      },
       resolveSentMessage: resolvedSentMessageFixture,
       storeFactory: { _ in try CommandTestDatabase.makeStoreForRPC() },
       resolveService: { _, _, _ in .imessage }
@@ -549,7 +567,10 @@ func sendCommandExplicitServiceSkipsDetection() async throws {
     try await SendCommand.run(
       values: values,
       runtime: runtime,
-      sendMessage: { options in captured = options },
+      sendMessage: { options in
+        captured = options
+        return options
+      },
       resolveSentMessage: resolvedSentMessageFixture,
       storeFactory: { _ in try CommandTestDatabase.makeStoreForRPC() },
       resolveService: { _, _, _ in

--- a/Tests/imsgTests/ChatsCommandTests.swift
+++ b/Tests/imsgTests/ChatsCommandTests.swift
@@ -29,14 +29,10 @@ func chatsUnreadOnlyFlagFiltersToUnreadChats() async throws {
 }
 
 @Test
-func chatsUnreadOnlyRejectsDatabaseWithoutReadState() async throws {
+func chatsUnreadOnlyRejectsDatabaseWithoutReadState() throws {
   let dbPath = try CommandTestDatabase.makePath()
-  let router = CommandRouter()
-
-  let (output, status) = await StdoutCapture.capture {
-    await router.run(argv: ["imsg", "chats", "--db", dbPath, "--unread-only", "--json"])
-  }
-
-  #expect(status == 1)
-  #expect(output.contains("Unread filtering is unavailable"))
+  let result = try runIMsgProcess(["chats", "--db", dbPath, "--unread-only", "--json"])
+  #expect(result.status == 1)
+  #expect(result.output.isEmpty)
+  #expect(result.error.contains("Unread filtering is unavailable"))
 }

--- a/Tests/imsgTests/CommandRouterTests.swift
+++ b/Tests/imsgTests/CommandRouterTests.swift
@@ -27,13 +27,12 @@ func commandRouterPrintsHelp() async {
 }
 
 @Test
-func commandRouterHonorsOptionTerminator() async {
+func commandRouterHonorsOptionTerminator() throws {
   for flag in ["--version", "-V", "--help", "-h"] {
-    let (output, status) = await StdoutCapture.capture {
-      await CommandRouter().run(argv: ["imsg", "completions", "--", flag])
-    }
-    #expect(status == 1)
-    #expect(output.contains("Unknown shell"))
+    let result = try runIMsgProcess(["completions", "--", flag])
+    #expect(result.status == 1)
+    #expect(result.output.isEmpty)
+    #expect(result.error.contains("Unknown shell"))
   }
 }
 
@@ -54,7 +53,7 @@ func executableWrapperPropagatesRouterStatus() throws {
 
   let invalid = try runIMsgProcess(["nope"])
   #expect(invalid.status == 1)
-  #expect(invalid.output.contains("nope") || invalid.output.contains("Unknown command"))
+  #expect(invalid.error.contains("nope") || invalid.error.contains("Unknown command"))
 }
 
 @Test
@@ -70,7 +69,7 @@ func stickerCommandRejectsFIFOWithoutWaitingForAWriter() throws {
     "send-sticker", "--chat", "iMessage;-;+15550000000", "--file", fifo.path,
   ])
   #expect(result.status == 1)
-  #expect(result.output.contains("sticker must be a regular file"))
+  #expect(result.error.contains("sticker must be a regular file"))
 }
 
 @Test
@@ -79,10 +78,10 @@ func commandRouterIncludesGroupCommand() {
   #expect(router.specs.contains { $0.name == "group" })
 }
 
-private func runIMsgProcess(
+func runIMsgProcess(
   _ arguments: [String],
   environment extraEnvironment: [String: String] = [:]
-) throws -> (status: Int32, output: String) {
+) throws -> (status: Int32, output: String, error: String) {
   let executable = try imsgExecutableURL()
   let process = Process()
   process.executableURL = executable
@@ -96,12 +95,18 @@ private func runIMsgProcess(
 
   let output = Pipe()
   process.standardOutput = output
-  process.standardError = output
+  let error = Pipe()
+  process.standardError = error
   try process.run()
   output.fileHandleForWriting.closeFile()
+  error.fileHandleForWriting.closeFile()
   #expect(!ProcessTimeout.waitUntilExit(process, timeout: 3))
   let data = output.fileHandleForReading.readDataToEndOfFile()
-  return (process.terminationStatus, String(data: data, encoding: .utf8) ?? "")
+  let errorData = error.fileHandleForReading.readDataToEndOfFile()
+  return (
+    process.terminationStatus, String(decoding: data, as: UTF8.self),
+    String(decoding: errorData, as: UTF8.self)
+  )
 }
 
 private func imsgExecutableURL() throws -> URL {
@@ -168,4 +173,16 @@ func completionsCommandRunsThroughRouter() async {
   }
   #expect(status == 0)
   #expect(output.contains("complete -c imsg"))
+}
+
+@Test(arguments: [
+  ["nope", "--json"],
+  ["search", "--query", "synthetic", "--match", "invalid", "--json"],
+  ["history", "--chat-id", "1", "--db", "/nonexistent/imsg-synthetic.db", "--json"],
+])
+func commandRouterKeepsDiagnosticsOffStdout(arguments: [String]) throws {
+  let result = try runIMsgProcess(arguments)
+  #expect(result.status == 1)
+  #expect(result.output.isEmpty)
+  #expect(!result.error.isEmpty)
 }

--- a/Tests/imsgTests/DirectParticipantRoutingTests.swift
+++ b/Tests/imsgTests/DirectParticipantRoutingTests.swift
@@ -16,7 +16,10 @@ func sendCommandSuppliesVerifiedParticipantRoute(target: String) async throws {
   _ = try await StdoutCapture.capture {
     try await SendCommand.run(
       values: values, runtime: RuntimeOptions(parsedValues: values),
-      sendMessage: { captured = $0 }, resolveSentMessage: resolvedSentMessageFixture)
+      sendMessage: {
+        captured = $0
+        return $0
+      }, resolveSentMessage: resolvedSentMessageFixture)
   }
   #expect(captured?.directParticipantTarget?.chatGUID == "iMessage;-;+123")
   #expect(captured?.directParticipantTarget?.recipient == "+123")
@@ -32,7 +35,10 @@ func rpcSuppliesVerifiedParticipantRoute(target: String) async throws {
   var captured: MessageSendOptions?
   let server = RPCServer(
     store: store, verbose: false, output: output,
-    sendMessage: { captured = $0 }, resolveSentMessage: resolvedSentMessageFixture)
+    sendMessage: {
+      captured = $0
+      return $0
+    }, resolveSentMessage: resolvedSentMessageFixture)
   let targetValue: Any = target == "to" ? "+123" : (target == "chat_id" ? 1 : "iMessage;-;+123")
   let request: [String: Any] = [
     "jsonrpc": "2.0", "id": 1, "method": "send",

--- a/Tests/imsgTests/RPCBridgeDeliveryTests.swift
+++ b/Tests/imsgTests/RPCBridgeDeliveryTests.swift
@@ -13,7 +13,10 @@ func rpcSendFallsBackOnlyWhenBridgeProvesNotStarted() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { options in captured = options },
+    sendMessage: { options in
+      captured = options
+      return options
+    },
     resolveSentMessage: resolvedSentMessageFixture,
     invokeBridge: { action, _ in
       throw DeliveryFailure(
@@ -77,7 +80,10 @@ func rpcSendFallsBackWhenBridgeIsNotReady() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in appleScriptCalled = true },
+    sendMessage: { options in
+      appleScriptCalled = true
+      return options
+    },
     resolveSentMessage: resolvedSentMessageFixture,
     invokeBridge: { _, _ in
       bridgeCalled = true

--- a/Tests/imsgTests/RPCContactFreshnessTests.swift
+++ b/Tests/imsgTests/RPCContactFreshnessTests.swift
@@ -55,7 +55,10 @@ import Testing
       store: store,
       verbose: false,
       output: output,
-      sendMessage: { sent = $0 },
+      sendMessage: {
+        sent = $0
+        return $0
+      },
       resolveSentMessage: resolvedSentMessageFixture,
       isBridgeReady: { false },
       contactResolver: contacts

--- a/Tests/imsgTests/RPCContractValidationTests.swift
+++ b/Tests/imsgTests/RPCContractValidationTests.swift
@@ -69,7 +69,10 @@ func rpcRejectsUnknownKeysAcrossHandlerFamilies() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in sent = true },
+    sendMessage: { options in
+      sent = true
+      return options
+    },
     invokeBridge: { _, _ in
       bridgeCalls += 1
       return [:]
@@ -138,7 +141,10 @@ func rpcRejectsConflictingTargetsBeforeMutations() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in sent = true },
+    sendMessage: { options in
+      sent = true
+      return options
+    },
     invokeBridge: { _, _ in
       bridgeCalls += 1
       return [:]
@@ -283,7 +289,10 @@ func rpcRejectsConflictingAliasesBeforeSideEffects() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in sendCalls += 1 },
+    sendMessage: { options in
+      sendCalls += 1
+      return options
+    },
     invokeBridge: { _, _ in
       bridgeCalls += 1
       return [:]

--- a/Tests/imsgTests/RPCFreshnessTests.swift
+++ b/Tests/imsgTests/RPCFreshnessTests.swift
@@ -102,7 +102,10 @@ func deletedWarmChatIDRejectsBeforeSendOrBridgeDispatch() async throws {
     store: fixture.store,
     verbose: false,
     output: output,
-    sendMessage: { _ in sendCount += 1 },
+    sendMessage: { options in
+      sendCount += 1
+      return options
+    },
     invokeBridge: { _, _ in
       bridgeCount += 1
       return [:]

--- a/Tests/imsgTests/RPCServerBridgeTests.swift
+++ b/Tests/imsgTests/RPCServerBridgeTests.swift
@@ -16,7 +16,10 @@ func rpcSendUsesBridgeWhenReadyAndExistingDirectChatResolves() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in appleScriptCalled = true },
+    sendMessage: { options in
+      appleScriptCalled = true
+      return options
+    },
     resolveSentMessage: { _, _, _, _ in nil },
     invokeBridge: { action, params in
       capturedAction = action
@@ -52,7 +55,10 @@ func rpcSendForwardsReplyTargetAliasesToBridge() async throws {
       store: store,
       verbose: false,
       output: output,
-      sendMessage: { _ in appleScriptCalled = true },
+      sendMessage: { options in
+        appleScriptCalled = true
+        return options
+      },
       resolveSentMessage: { _, _, _, _ in nil },
       invokeBridge: { action, params in
         capturedAction = action
@@ -88,7 +94,10 @@ func rpcSendForwardsCaptionedAttachmentReplyToBridge() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in appleScriptCalled = true },
+    sendMessage: { options in
+      appleScriptCalled = true
+      return options
+    },
     resolveSentMessage: { _, _, _, _ in nil },
     invokeBridge: { action, params in
       capturedActions.append(action)
@@ -141,7 +150,10 @@ func rpcSendReplyAttachmentRejectsStaleBridge() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in appleScriptCalled = true },
+    sendMessage: { options in
+      appleScriptCalled = true
+      return options
+    },
     resolveSentMessage: { _, _, _, _ in nil },
     invokeBridge: { action, _ in
       capturedActions.append(action)
@@ -175,7 +187,7 @@ func rpcSendThreadsTextFormattingToBridge() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in },
+    sendMessage: { $0 },
     resolveSentMessage: { _, _, _, _ in nil },
     invokeBridge: { _, params in
       capturedParams = params
@@ -207,7 +219,7 @@ func rpcSendWithoutFormattingOmitsTextFormatting() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in },
+    sendMessage: { $0 },
     resolveSentMessage: { _, _, _, _ in nil },
     invokeBridge: { _, params in
       capturedParams = params
@@ -256,7 +268,10 @@ func rpcSendAutoSMSDetectionKeepsAnyPrefixBridgeLookup() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in appleScriptCalled = true },
+    sendMessage: { options in
+      appleScriptCalled = true
+      return options
+    },
     resolveSentMessage: { _, _, _, _ in nil },
     invokeBridge: { action, params in
       capturedAction = action
@@ -290,7 +305,7 @@ func rpcSendAutoSMSDetectionDoesNotUseIMessageBridgeChat() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in },
+    sendMessage: { $0 },
     resolveSentMessage: { _, _, _, _ in nil },
     invokeBridge: { _, _ in
       bridgeCalled = true
@@ -317,7 +332,10 @@ func rpcSendDoesNotFallbackWhenBridgeFailureIsUncertain() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { options in captured = options },
+    sendMessage: { options in
+      captured = options
+      return options
+    },
     resolveSentMessage: { _, _, _, _ in nil },
     invokeBridge: { _, _ in throw IMsgBridgeError.dylibReturnedError("nope") },
     isBridgeReady: { true }
@@ -346,7 +364,10 @@ func rpcSendReplyTargetRejectsAppleScriptFallbackWhenBridgeUnavailable() async t
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in appleScriptCalled = true },
+    sendMessage: { options in
+      appleScriptCalled = true
+      return options
+    },
     resolveSentMessage: { _, _, _, _ in nil },
     invokeBridge: { _, _ in
       bridgeCalled = true
@@ -378,7 +399,10 @@ func rpcSendReplyTargetDoesNotFallbackToAppleScriptWhenBridgeFails() async throw
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in appleScriptCalled = true },
+    sendMessage: { options in
+      appleScriptCalled = true
+      return options
+    },
     resolveSentMessage: { _, _, _, _ in nil },
     invokeBridge: { _, _ in
       bridgeCalled = true

--- a/Tests/imsgTests/RPCServerSendFallbackTests.swift
+++ b/Tests/imsgTests/RPCServerSendFallbackTests.swift
@@ -14,7 +14,10 @@ func rpcSendEnablesSMSFallbackForAutoTextDirectSend() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { options in captured = options },
+    sendMessage: { options in
+      captured = options
+      return options
+    },
     resolveSentMessage: resolvedSentMessageFixture
   )
 
@@ -36,7 +39,10 @@ func rpcSendCanDisableOtherwiseEligibleSMSFallbackWithoutChangingAutoService() a
       store: store,
       verbose: false,
       output: output,
-      sendMessage: { captured = $0 },
+      sendMessage: {
+        captured = $0
+        return $0
+      },
       resolveSentMessage: resolvedSentMessageFixture
     )
 
@@ -71,7 +77,10 @@ func rpcSendAutoUsesLocalSMSHistoryForAttachmentSend() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { options in captured = options },
+    sendMessage: { options in
+      captured = options
+      return options
+    },
     resolveSentMessage: resolvedSentMessageFixture
   )
 
@@ -103,7 +112,10 @@ func rpcSendAutoDetectionUsesRegionNormalizedRecipient() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { options in captured = options },
+    sendMessage: { options in
+      captured = options
+      return options
+    },
     resolveSentMessage: { _, _, _, _ in nil }
   )
 
@@ -124,7 +136,10 @@ func rpcSendDisablesSMSFallbackForExplicitService() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { options in captured = options },
+    sendMessage: { options in
+      captured = options
+      return options
+    },
     resolveSentMessage: resolvedSentMessageFixture
   )
 

--- a/Tests/imsgTests/RPCServerTests.swift
+++ b/Tests/imsgTests/RPCServerTests.swift
@@ -145,7 +145,10 @@ func rpcSendResolvesChatID() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { options in captured = options },
+    sendMessage: { options in
+      captured = options
+      return options
+    },
     resolveSentMessage: resolvedSentMessageFixture
   )
 
@@ -170,7 +173,10 @@ func rpcSendResolvesUniqueContactName() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { options in captured = options },
+    sendMessage: { options in
+      captured = options
+      return options
+    },
     resolveSentMessage: resolvedSentMessageFixture,
     contactResolver: resolver
   )
@@ -211,7 +217,10 @@ func rpcSendRejectsContactNameWhenContactsAreUnavailable() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in didSend = true },
+    sendMessage: { options in
+      didSend = true
+      return options
+    },
     contactResolver: resolver
   )
 
@@ -231,7 +240,7 @@ func rpcSendReturnsSentMessageIdentifiersWhenResolved() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in },
+    sendMessage: { $0 },
     resolveSentMessage: { _, options, chatID, _ in
       Message(
         rowID: 1_979,
@@ -268,7 +277,7 @@ func rpcAttachmentOnlyKeepsOkResponseWithoutTextVerification() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in },
+    sendMessage: { $0 },
     resolveSentMessage: { _, _, _, _ in nil }
   )
 
@@ -292,7 +301,7 @@ func rpcSendReportsMisroutedChatGhost() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in
+    sendMessage: { options in
       try store.withConnection { db in
         try db.run("INSERT INTO handle(ROWID, id) VALUES (99, 'iMessage;+;chat123')")
         try db.run(
@@ -303,6 +312,7 @@ func rpcSendReportsMisroutedChatGhost() async throws {
           CommandTestDatabase.appleEpoch(Date())
         )
       }
+      return options
     },
     resolveSentMessage: { _, _, _, _ in nil }
   )

--- a/Tests/imsgTests/RPCStatusTestSupport.swift
+++ b/Tests/imsgTests/RPCStatusTestSupport.swift
@@ -80,7 +80,7 @@ func rpcStatusMethods(_ snapshot: [String: Any]) -> Set<String> {
 func makeUnavailableRPCStatusServer(
   output: TestRPCOutput,
   bridgeReady: Bool = false,
-  sendMessage: @escaping (MessageSendOptions) throws -> Void = { _ in },
+  sendMessage: @escaping (MessageSendOptions) throws -> MessageSendOptions = { $0 },
   invokeBridge: @escaping BridgeInvoker = { _, _ in [:] }
 ) -> RPCServer {
   RPCServer(

--- a/Tests/imsgTests/RPCStatusTests.swift
+++ b/Tests/imsgTests/RPCStatusTests.swift
@@ -158,7 +158,10 @@ func rpcDatabaseUnavailableIsTypedWhileDirectSendStillWorks() async throws {
   var sent: MessageSendOptions?
   let server = makeUnavailableRPCStatusServer(
     output: output,
-    sendMessage: { sent = $0 }
+    sendMessage: {
+      sent = $0
+      return $0
+    }
   )
 
   await server.handleLineForTesting(
@@ -296,7 +299,10 @@ func rpcBridgePreflightNeverInvokesWhenReadyLockIsAbsentAndAutoSendFallsBack() a
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in sent = true },
+    sendMessage: { options in
+      sent = true
+      return options
+    },
     resolveSentMessage: resolvedSentMessageFixture,
     invokeBridge: { _, _ in
       invocations.increment()

--- a/Tests/imsgTests/RPCTrackedSendTests.swift
+++ b/Tests/imsgTests/RPCTrackedSendTests.swift
@@ -25,7 +25,10 @@ func rpcTrackedSendForwardsCallerOwnedGuidAndReturnsExactIdentity() async throws
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in appleScriptCalled = true },
+    sendMessage: { options in
+      appleScriptCalled = true
+      return options
+    },
     resolveSentMessage: { _, _, _, _ in nil },
     invokeBridge: { action, params in
       capturedActions.append(action)
@@ -65,7 +68,10 @@ func rpcTrackedSendRejectsBeforeDispatchWithoutCurrentHelperCapability() async t
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in appleScriptCalled = true },
+    sendMessage: { options in
+      appleScriptCalled = true
+      return options
+    },
     resolveSentMessage: { _, _, _, _ in nil },
     invokeBridge: { action, _ in
       capturedActions.append(action)
@@ -99,7 +105,10 @@ func rpcTrackedSendRejectsExistingGuidCaseInsensitivelyBeforeBridgeIO() async th
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in appleScriptCalled = true },
+    sendMessage: { options in
+      appleScriptCalled = true
+      return options
+    },
     invokeBridge: { _, _ in
       bridgeCalled = true
       return [:]
@@ -128,7 +137,10 @@ func rpcTrackedSendNeverFallsBackAfterUncertainBridgeDispatch() async throws {
     store: store,
     verbose: false,
     output: output,
-    sendMessage: { _ in appleScriptCalled = true },
+    sendMessage: { options in
+      appleScriptCalled = true
+      return options
+    },
     invokeBridge: { action, _ in
       actions.append(action)
       if action == .status {

--- a/Tests/imsgTests/ScheduledCommandTests.swift
+++ b/Tests/imsgTests/ScheduledCommandTests.swift
@@ -35,11 +35,10 @@ func scheduledCommandPlainOutputAndLimitValidation() async throws {
   #expect(output.contains("scheduled-one"))
   #expect(output.contains("later one"))
 
-  let (badOutput, badStatus) = await StdoutCapture.capture {
-    await router.run(argv: ["imsg", "scheduled", "list", "--db", path, "--limit", "0"])
-  }
-  #expect(badStatus == 1)
-  #expect(badOutput.contains("--limit"))
+  let invalid = try runIMsgProcess(["scheduled", "list", "--db", path, "--limit", "0"])
+  #expect(invalid.status == 1)
+  #expect(invalid.output.isEmpty)
+  #expect(invalid.error.contains("--limit"))
 }
 
 @Test

--- a/Tests/imsgTests/SendCommandServiceDetectionTests.swift
+++ b/Tests/imsgTests/SendCommandServiceDetectionTests.swift
@@ -27,7 +27,10 @@ func sendCommandDirectSendDoesNotRequireMessagesDatabase() async throws {
     try await SendCommand.run(
       values: values,
       runtime: runtime,
-      sendMessage: { options in captured = options },
+      sendMessage: { options in
+        captured = options
+        return options
+      },
       resolveSentMessage: { _, _, _, _ in nil },
       storeFactory: { _ in throw SendCommandServiceDetectionTestError.unavailable }
     )
@@ -69,7 +72,10 @@ func sendCommandAutoDetectionUsesRegionNormalizedRecipient() async throws {
     try await SendCommand.run(
       values: values,
       runtime: runtime,
-      sendMessage: { options in captured = options },
+      sendMessage: { options in
+        captured = options
+        return options
+      },
       resolveSentMessage: { _, _, _, _ in nil }
     )
   }

--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -3,7 +3,7 @@ title: Attachments
 description: "Attachment metadata, resolved paths, and optional model-friendly conversion for CAF audio and GIF images."
 ---
 
-`imsg` reports attachment metadata only. It never copies, modifies, or uploads the underlying files. Optional conversion exposes cached, model-friendly variants for CAF audio and GIF images.
+Reading attachments reports metadata and paths without modifying the originals. Optional conversion creates cached variants for CAF audio and GIF images. Sending stages a private copy for Messages to read, as described below.
 
 ## Reading attachments
 

--- a/docs/send.md
+++ b/docs/send.md
@@ -23,7 +23,7 @@ imsg send --to "Jane Appleseed" --text "hi"
 For unambiguous routing, prefer phone numbers in E.164 form.
 
 When `chat.db` is readable and the recipient already has a direct chat, `imsg`
-targets that chat's GUID instead of constructing a new buddy send. New
+targets a compatible chat's GUID instead of constructing a new buddy send. Explicit `sms` and `imessage` selection never reuse a chat on the opposite service. New
 recipients still use the existing buddy-send behavior.
 
 If that GUID is absent from Messages.app's live chats, `imsg` recovers from
@@ -93,7 +93,7 @@ state, not wording inferred from an error message.
 imsg send --to "415-555-1212" --text "hi" --region US
 ```
 
-Defaults to `US`. Pass an ISO 3166-1 alpha-2 country code to normalize locally-formatted numbers. `--service auto` uses the same normalized phone number when checking local Messages history, so SMS-only history is detected for local-format numbers outside the US too.
+Defaults to `US`. Pass an ISO 3166-1 alpha-2 country code to normalize locally-formatted numbers. Chat selection, service detection, dispatch, and verification use the same normalized recipient, including local-format numbers outside the US.
 
 ## Confirming what was sent
 
@@ -102,8 +102,7 @@ Default text mode prints `sent` on success. JSON mode emits `{"status":"sent"}`.
 When `chat.db` is readable, every AppleScript text send waits up to eight
 seconds for the matching outgoing row. If Messages reports success but no row
 appears, `imsg` returns `may_have_completed` with no-retry guidance instead of
-reporting success. The lookup uses the known chat rowid when available and a
-bounded global text lookup for a new recipient. Direct sends still retain the
+reporting success. The lookup is scoped to the actual send route; after a safe SMS fallback, it verifies the SMS chat and reports that message's ID and service. A new recipient's chat must become visible before its text can be confirmed. Direct sends still retain the
 previous accepted behavior when the database is unavailable. Attachment-only
 verification is unchanged.
 


### PR DESCRIPTION
Carry the effective send route through verification and RPC output. Local-format recipients are normalized before chat selection. Explicit SMS/iMessage requests only reuse compatible chats; auto-detected SMS retains the shipped neutral `any;…` lookup behavior even when chat service metadata is stale.

`MessageSender.sendResolvingRoute` returns the normalized destination from the successful attempt. Safe SMS fallback clears the abandoned chat/account target, so verification cannot confirm an unrelated same-text iMessage or report its GUID/service. The existing public `send` function retains its Void signature and delegates to the same implementation. CLI/RPC share target resolution from the returned route, and a database failure after dispatch remains delivery-unknown.

Generic CLI diagnostics and error-triggered help now go to stderr, matching the README. Explicit help/version and command-owned JSON envelopes keep their existing streams. Removed the redundant nested error handler and corrected attachment docs to describe staging copies.

Validation: before repair, eight recipient/service assertions and six real `MessageSender` fallback assertions failed; the latter demonstrated confirming the wrong chat's same-text message. Three subprocess probes also found plain diagnostics on stdout. The final local suite passes 741 Swift tests, native fixtures, docs checks, and lint with 15 existing warnings. Coverage includes CLI/RPC normalization, SMS fallback identity, explicit-service selection, stale neutral-chat compatibility, post-dispatch database failure, account-scoped recovery, and separated stdout/stderr. Independent Codex review found no actionable P0–P2 defects. Transport tests use injected runners and synthetic databases; no real recipient was designated for live sends.

Production grows by six lines for the returned-route contract and shared normalization API. Most test changes mechanically return the observed route from existing sender spies; subprocess diagnostics tests now inspect both streams. Existing attachment-only sending and the public Void API remain covered.
