### PR TITLE
fix: serialize Messages bridge launches across processes

### DIFF
--- a/Sources/IMsgCore/BridgeLaunchCoordinator.swift
+++ b/Sources/IMsgCore/BridgeLaunchCoordinator.swift
@@ -1,8 +1,17 @@
 import Foundation
 
-/// Process-local serial owner for Messages.app launch/readiness.
+#if os(macOS)
+  import Darwin
+#endif
+
+/// Serial owner for Messages.app launch/readiness within and across processes.
 final class BridgeLaunchCoordinator: @unchecked Sendable {
   private let queue = DispatchQueue(label: "imsg.bridge-launch-coordinator")
+  private let lockFilePath: String?
+
+  init(lockFilePath: String? = nil) {
+    self.lockFilePath = lockFilePath
+  }
 
   func run(
     readinessCheck: @escaping @Sendable () -> Bool,
@@ -15,8 +24,11 @@ final class BridgeLaunchCoordinator: @unchecked Sendable {
         queue.async {
           guard request.isPending else { return }
           let result = Result {
-            if !readinessCheck() {
-              try operation()
+            try self.withLaunchLock {
+              guard request.isPending else { return }
+              if !readinessCheck() {
+                try operation()
+              }
             }
           }
           request.resume(with: result)
@@ -32,11 +44,60 @@ final class BridgeLaunchCoordinator: @unchecked Sendable {
     operation: @Sendable () throws -> Void
   ) throws {
     try queue.sync {
-      if !readinessCheck() {
-        try operation()
+      try withLaunchLock {
+        if !readinessCheck() {
+          try operation()
+        }
       }
     }
   }
+
+  private func withLaunchLock(_ operation: () throws -> Void) throws {
+    guard let lockFilePath else {
+      try operation()
+      return
+    }
+
+    #if os(macOS)
+      if SecurePath.hasSymlinkComponent(lockFilePath) {
+        throw MessagesLauncherError.socketError(
+          "launch lock path traverses a symlink: \(lockFilePath)")
+      }
+
+      let descriptor = open(lockFilePath, O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, 0o600)
+      guard descriptor >= 0 else {
+        throw Self.lockError(action: "open", path: lockFilePath)
+      }
+      defer { close(descriptor) }
+
+      var metadata = stat()
+      guard fstat(descriptor, &metadata) == 0 else {
+        throw Self.lockError(action: "inspect", path: lockFilePath)
+      }
+      guard metadata.st_uid == geteuid(), (metadata.st_mode & S_IFMT) == S_IFREG,
+        metadata.st_nlink == 1, (metadata.st_mode & 0o077) == 0
+      else {
+        throw MessagesLauncherError.socketError(
+          "launch lock must be an owner-only regular file: \(lockFilePath)")
+      }
+
+      guard flock(descriptor, LOCK_EX) == 0 else {
+        throw Self.lockError(action: "acquire", path: lockFilePath)
+      }
+      defer { _ = flock(descriptor, LOCK_UN) }
+
+      try operation()
+    #else
+      try operation()
+    #endif
+  }
+
+  #if os(macOS)
+    private static func lockError(action: String, path: String) -> MessagesLauncherError {
+      let details = String(cString: strerror(errno))
+      return .socketError("could not \(action) launch lock \(path): \(details)")
+    }
+  #endif
 }
 
 private final class AsyncLaunchRequest: @unchecked Sendable {

--- a/Sources/IMsgCore/BridgeLaunchCoordinator.swift
+++ b/Sources/IMsgCore/BridgeLaunchCoordinator.swift
@@ -59,6 +59,21 @@ final class BridgeLaunchCoordinator: @unchecked Sendable {
     }
 
     #if os(macOS)
+      let parentDirectory = (lockFilePath as NSString).deletingLastPathComponent
+      if SecurePath.hasSymlinkComponent(parentDirectory) {
+        throw MessagesLauncherError.socketError(
+          "launch lock path traverses a symlink: \(lockFilePath)")
+      }
+      do {
+        try FileManager.default.createDirectory(
+          atPath: parentDirectory,
+          withIntermediateDirectories: true,
+          attributes: [.posixPermissions: 0o700])
+      } catch {
+        throw MessagesLauncherError.socketError(
+          "could not create launch lock directory \(parentDirectory): "
+            + error.localizedDescription)
+      }
       if SecurePath.hasSymlinkComponent(lockFilePath) {
         throw MessagesLauncherError.socketError(
           "launch lock path traverses a symlink: \(lockFilePath)")

--- a/Sources/IMsgCore/MessagesLauncher.swift
+++ b/Sources/IMsgCore/MessagesLauncher.swift
@@ -52,7 +52,7 @@ import Foundation
       "/System/Applications/Messages.app/Contents/MacOS/Messages"
     private let queue = DispatchQueue(label: "imsg.messages.launcher")
     private let commandLock = NSLock()
-    private let launchCoordinator = BridgeLaunchCoordinator()
+    private let launchCoordinator: BridgeLaunchCoordinator
     private let containerPathOverride: String?
     private let readyCheckOverride: (() -> Bool)?
     private let injectedReadyCheckOverride: (() -> Bool)?
@@ -71,6 +71,10 @@ import Foundation
       self.readyCheckOverride = readyCheck
       self.injectedReadyCheckOverride = injectedReadyCheck
       self.launchOverride = launch
+      self.launchCoordinator = BridgeLaunchCoordinator(
+        lockFilePath: (containerPath
+          ?? NSHomeDirectory() + "/Library/Containers/com.apple.MobileSMS/Data")
+          + "/.imsg-launch.lock")
       if let path = BridgeHelperLocator.resolve() {
         self.dylibPath = path
       }

--- a/Tests/IMsgCoreTests/IMsgBridgeClientQueueTests.swift
+++ b/Tests/IMsgCoreTests/IMsgBridgeClientQueueTests.swift
@@ -325,6 +325,7 @@ struct IMsgBridgeClientQueueTests {
     let state = LaunchAttemptState()
     let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
     defer { try? FileManager.default.removeItem(at: root) }
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
     let launcher = MessagesLauncher(
       containerPath: root.path,
       readyCheck: { state.checkReady() },
@@ -354,10 +355,65 @@ struct IMsgBridgeClientQueueTests {
     #expect(try await second.value != nil)
     #expect(state.attemptCount == 1)
   }
+
+  @Test
+  func independentLaunchersShareOneLaunchAttempt() async throws {
+    let state = LaunchAttemptState()
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    defer { try? FileManager.default.removeItem(at: root) }
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+    let makeLauncher = {
+      MessagesLauncher(
+        containerPath: root.path,
+        readyCheck: { state.checkReady() },
+        launch: { state.launch() })
+    }
+    let firstLauncher = makeLauncher()
+    let secondLauncher = makeLauncher()
+
+    let first = Task.detached { try await firstLauncher.ensureLaunched() }
+    await state.launchStarted.wait()
+    let second = Task.detached {
+      state.secondTaskScheduled.signal()
+      try await secondLauncher.ensureLaunched()
+    }
+    await state.secondTaskScheduled.wait()
+    state.allowLaunch()
+
+    try await first.value
+    try await second.value
+    #expect(state.attemptCount == 1)
+  }
+
+  @Test
+  func launchFailureReleasesSharedLock() throws {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    defer { try? FileManager.default.removeItem(at: root) }
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+    let failingLauncher = MessagesLauncher(
+      containerPath: root.path,
+      readyCheck: { false },
+      launch: { throw BridgeClientTestError.launchFailed })
+    #expect(throws: BridgeClientTestError.launchFailed) {
+      try failingLauncher.ensureLaunched()
+    }
+
+    let state = LaunchAttemptState()
+    let recoveringLauncher = MessagesLauncher(
+      containerPath: root.path,
+      readyCheck: { state.checkReady() },
+      launch: { state.markReady() })
+    try recoveringLauncher.ensureLaunched()
+
+    #expect(state.attemptCount == 1)
+  }
 }
 
-private enum BridgeClientTestError: Error {
+private enum BridgeClientTestError: Error, Equatable {
   case expectedDeliveryFailure
+  case launchFailed
 }
 
 private func deliveryFailure(
@@ -439,9 +495,12 @@ private final class LaunchAttemptState: @unchecked Sendable {
   func launch() {
     lock.lock()
     attempts += 1
+    let shouldWait = attempts == 1
     lock.unlock()
     launchStarted.signal()
-    launchGate.wait()
+    if shouldWait {
+      launchGate.wait()
+    }
     lock.lock()
     ready = true
     lock.unlock()
@@ -449,6 +508,13 @@ private final class LaunchAttemptState: @unchecked Sendable {
 
   func allowLaunch() {
     launchGate.signal()
+  }
+
+  func markReady() {
+    lock.lock()
+    attempts += 1
+    ready = true
+    lock.unlock()
   }
 
   func nextID() -> String {

--- a/Tests/IMsgCoreTests/IMsgBridgeClientQueueTests.swift
+++ b/Tests/IMsgCoreTests/IMsgBridgeClientQueueTests.swift
@@ -325,7 +325,6 @@ struct IMsgBridgeClientQueueTests {
     let state = LaunchAttemptState()
     let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
     defer { try? FileManager.default.removeItem(at: root) }
-    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
     let launcher = MessagesLauncher(
       containerPath: root.path,
       readyCheck: { state.checkReady() },
@@ -361,7 +360,6 @@ struct IMsgBridgeClientQueueTests {
     let state = LaunchAttemptState()
     let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
     defer { try? FileManager.default.removeItem(at: root) }
-    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
 
     let makeLauncher = {
       MessagesLauncher(
@@ -384,13 +382,13 @@ struct IMsgBridgeClientQueueTests {
     try await first.value
     try await second.value
     #expect(state.attemptCount == 1)
+    #expect(FileManager.default.fileExists(atPath: root.path))
   }
 
   @Test
   func launchFailureReleasesSharedLock() throws {
     let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
     defer { try? FileManager.default.removeItem(at: root) }
-    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
 
     let failingLauncher = MessagesLauncher(
       containerPath: root.path,


### PR DESCRIPTION
## Summary

- securely provision the lock parent and serialize the complete Messages bridge launch lifecycle with a per-container POSIX file lock
- re-check readiness after acquiring the lock so waiting launchers reuse the instance started by the owner
- reject symlinked, shared, non-regular, or multiply linked lock files and keep the descriptor close-on-exec
- cover independent launcher instances and lock release after launch failure

Closes #272.

## Behavior proof

A compiled coordinator harness drove two independent launch owners against the same readiness state. With process-local coordination only it recorded two launch operations; with the shared lock it recorded one (`unlocked=2`, `locked=1`). The regression test uses the same independent-launcher composition from an absent container directory, and the failure-path test verifies that a throwing owner releases the lock for the next launcher.

The lock is held across readiness re-check, cleanup, spawn, and readiness wait. Because the descriptor uses `O_CLOEXEC`, the launched Messages process does not inherit ownership; process exit also releases the kernel lock.

## Validation

- `swiftc -frontend -parse Sources/IMsgCore/BridgeLaunchCoordinator.swift Sources/IMsgCore/MessagesLauncher.swift Tests/IMsgCoreTests/IMsgBridgeClientQueueTests.swift`
- `node --test scripts/build-docs-site.test.mjs`
- `make test-helper`
- `git diff --check`

`make test` could not start in the local Command Line Tools-only environment because XCTest was unavailable. Hosted CI remains the full Swift-suite validation. No live Messages relaunch was performed, so the reporter's native duplicate-process evidence remains the live-system proof.

Disclosure: AI was used to understand the codebase and review the fix.
