### PR TITLE
fix: make bridge launch readiness timeout configurable

### DIFF
--- a/Sources/IMsgCore/LaunchReadinessTimeout.swift
+++ b/Sources/IMsgCore/LaunchReadinessTimeout.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// How long `imsg launch` waits for Messages.app to publish the bridge-ready
+/// lock file before giving up.
+///
+/// A cold start after a crash, or a machine under load, can exceed the default.
+/// Reporting that as a failure is actively harmful: a supervisor that relaunches
+/// on a non-zero exit will start a second Messages.app while the first is still
+/// coming up, and two injected instances then compete for the same bridge queue.
+enum LaunchReadinessTimeout {
+  /// Seconds to wait when nothing overrides it.
+  static let defaultSeconds: TimeInterval = 15
+
+  /// Upper bound, so a typo cannot hang a launch indefinitely.
+  static let maximumSeconds: TimeInterval = 600
+
+  /// Environment variable that overrides the default.
+  static let environmentKey = "IMSG_LAUNCH_READY_TIMEOUT"
+
+  /// Resolve the timeout, falling back to the default for anything unusable.
+  static func resolve(
+    environment: [String: String] = ProcessInfo.processInfo.environment
+  ) -> TimeInterval {
+    guard let raw = environment[environmentKey],
+      let parsed = TimeInterval(raw.trimmingCharacters(in: .whitespaces)),
+      parsed.isFinite, parsed > 0
+    else {
+      return defaultSeconds
+    }
+    return min(parsed, maximumSeconds)
+  }
+}

--- a/Sources/IMsgCore/MessagesLauncher.swift
+++ b/Sources/IMsgCore/MessagesLauncher.swift
@@ -333,7 +333,7 @@ import Foundation
         return
       }
 
-      throw MessagesLauncherError.socketTimeout(seconds: timeout)
+      throw MessagesLauncherError.socketTimeout
     }
 
     private func sendCommandSync(
@@ -469,7 +469,7 @@ public enum MessagesLauncherError: Error, CustomStringConvertible {
   case launchFailed(String)
   case sipEnabled
   case sipStatusUnknown(String)
-  case socketTimeout(seconds: TimeInterval)
+  case socketTimeout
   case socketError(String)
   case invalidResponse
   case commandNotPublished(String)
@@ -491,14 +491,18 @@ public enum MessagesLauncherError: Error, CustomStringConvertible {
         "Unable to determine SIP status. "
         + "Refusing to inject into Messages.app. "
         + "Details: \(details)"
-    case .socketTimeout(let seconds):
+    case .socketTimeout:
+      // Resolved rather than stored: the case stays payload-free so external
+      // `.socketTimeout` construction keeps compiling, and `waitForReady` is
+      // only ever called with this same resolved value.
+      let seconds = LaunchReadinessTimeout.resolve()
       return
         "Messages.app did not report the bridge ready within "
         + "\(String(format: "%g", seconds))s. It may still be starting; re-check "
         + "with `imsg status` before relaunching, and raise "
-        + "IMSG_LAUNCH_READY_TIMEOUT if this host is consistently slower. "
-        + "If it never becomes ready, verify SIP is disabled and Messages.app "
-        + "has the necessary permissions."
+        + "\(LaunchReadinessTimeout.environmentKey) if this host is consistently "
+        + "slower. If it never becomes ready, verify SIP is disabled and "
+        + "Messages.app has the necessary permissions."
     case .socketError(let reason):
       return "IPC error: \(reason)"
     case .invalidResponse:

--- a/Sources/IMsgCore/MessagesLauncher.swift
+++ b/Sources/IMsgCore/MessagesLauncher.swift
@@ -156,7 +156,7 @@ import Foundation
       try cleanQueueDirectory(bridgeOutboxDirectory)
 
       try launchWithInjection()
-      try waitForReady(timeout: 15.0)
+      try waitForReady(timeout: LaunchReadinessTimeout.resolve())
     }
 
     private func ensureSecureQueueDirectory(_ path: String) throws {
@@ -326,7 +326,14 @@ import Foundation
         Thread.sleep(forTimeInterval: 0.5)
       }
 
-      throw MessagesLauncherError.socketTimeout
+      // Readiness can land in the gap between the last poll and the deadline.
+      // Without this check a launch that actually succeeded is reported as a
+      // failure, which invites a caller to launch a second time.
+      if FileManager.default.fileExists(atPath: lockFile) {
+        return
+      }
+
+      throw MessagesLauncherError.socketTimeout(seconds: timeout)
     }
 
     private func sendCommandSync(
@@ -462,7 +469,7 @@ public enum MessagesLauncherError: Error, CustomStringConvertible {
   case launchFailed(String)
   case sipEnabled
   case sipStatusUnknown(String)
-  case socketTimeout
+  case socketTimeout(seconds: TimeInterval)
   case socketError(String)
   case invalidResponse
   case commandNotPublished(String)
@@ -484,10 +491,14 @@ public enum MessagesLauncherError: Error, CustomStringConvertible {
         "Unable to determine SIP status. "
         + "Refusing to inject into Messages.app. "
         + "Details: \(details)"
-    case .socketTimeout:
+    case .socketTimeout(let seconds):
       return
-        "Timeout waiting for Messages.app to initialize. "
-        + "Ensure SIP is disabled and Messages.app has necessary permissions."
+        "Messages.app did not report the bridge ready within "
+        + "\(String(format: "%g", seconds))s. It may still be starting; re-check "
+        + "with `imsg status` before relaunching, and raise "
+        + "IMSG_LAUNCH_READY_TIMEOUT if this host is consistently slower. "
+        + "If it never becomes ready, verify SIP is disabled and Messages.app "
+        + "has the necessary permissions."
     case .socketError(let reason):
       return "IPC error: \(reason)"
     case .invalidResponse:

--- a/Tests/IMsgCoreTests/IMCoreBridgeTests.swift
+++ b/Tests/IMsgCoreTests/IMCoreBridgeTests.swift
@@ -41,7 +41,7 @@ func messagesLauncherErrorDescriptions() {
   let errors: [MessagesLauncherError] = [
     .dylibNotFound("/fake/path"),
     .launchFailed("test reason"),
-    .socketTimeout,
+    .socketTimeout(seconds: 15),
     .socketError("test error"),
     .invalidResponse,
   ]
@@ -49,6 +49,48 @@ func messagesLauncherErrorDescriptions() {
   for error in errors {
     #expect(!error.description.isEmpty)
   }
+}
+
+@Test
+func readinessTimeoutFallsBackToDefaultWithoutOverride() {
+  #expect(
+    LaunchReadinessTimeout.resolve(environment: [:])
+      == LaunchReadinessTimeout.defaultSeconds)
+}
+
+@Test
+func readinessTimeoutHonorsEnvironmentOverride() {
+  #expect(
+    LaunchReadinessTimeout.resolve(
+      environment: ["IMSG_LAUNCH_READY_TIMEOUT": "45"]) == 45)
+  #expect(
+    LaunchReadinessTimeout.resolve(
+      environment: ["IMSG_LAUNCH_READY_TIMEOUT": " 30.5 "]) == 30.5)
+}
+
+@Test
+func readinessTimeoutRejectsUnusableOverrides() {
+  for raw in ["", "abc", "0", "-5", "nan"] {
+    #expect(
+      LaunchReadinessTimeout.resolve(
+        environment: ["IMSG_LAUNCH_READY_TIMEOUT": raw])
+        == LaunchReadinessTimeout.defaultSeconds,
+      "unusable override \(raw) should fall back to the default")
+  }
+}
+
+@Test
+func readinessTimeoutIsClampedToAnUpperBound() {
+  #expect(
+    LaunchReadinessTimeout.resolve(
+      environment: ["IMSG_LAUNCH_READY_TIMEOUT": "99999"]) == 600)
+}
+
+@Test
+func socketTimeoutDescriptionReportsTheTimeoutUsed() {
+  let description = MessagesLauncherError.socketTimeout(seconds: 15).description
+  #expect(description.contains("15s"))
+  #expect(description.contains("IMSG_LAUNCH_READY_TIMEOUT"))
 }
 
 @Test

--- a/Tests/IMsgCoreTests/IMCoreBridgeTests.swift
+++ b/Tests/IMsgCoreTests/IMCoreBridgeTests.swift
@@ -41,7 +41,7 @@ func messagesLauncherErrorDescriptions() {
   let errors: [MessagesLauncherError] = [
     .dylibNotFound("/fake/path"),
     .launchFailed("test reason"),
-    .socketTimeout(seconds: 15),
+    .socketTimeout,
     .socketError("test error"),
     .invalidResponse,
   ]
@@ -87,10 +87,40 @@ func readinessTimeoutIsClampedToAnUpperBound() {
 }
 
 @Test
-func socketTimeoutDescriptionReportsTheTimeoutUsed() {
-  let description = MessagesLauncherError.socketTimeout(seconds: 15).description
-  #expect(description.contains("15s"))
-  #expect(description.contains("IMSG_LAUNCH_READY_TIMEOUT"))
+func socketTimeoutDescriptionReportsTheTimeoutAndOverride() {
+  let description = MessagesLauncherError.socketTimeout.description
+  #expect(description.contains("\(String(format: "%g", LaunchReadinessTimeout.resolve()))s"))
+  #expect(description.contains(LaunchReadinessTimeout.environmentKey))
+  // The old text blamed SIP/permissions first; the cause is usually a slow start.
+  #expect(description.contains("still be starting"))
+}
+
+/// Source-compatibility fixture.
+///
+/// `MessagesLauncherError` is public API in an exported library, so external
+/// callers construct and match `.socketTimeout` without a payload. These are the
+/// shapes such a caller uses; if the case ever gains a required associated
+/// value this stops compiling, which is the point.
+@Test
+func socketTimeoutKeepsPayloadFreePublicConstruction() {
+  let viaMemberSyntax: MessagesLauncherError = .socketTimeout
+  let viaFullyQualified = MessagesLauncherError.socketTimeout
+  let inCollection: [MessagesLauncherError] = [.socketTimeout]
+
+  func classify(_ error: MessagesLauncherError) -> String {
+    switch error {
+    case .socketTimeout: return "timeout"
+    default: return "other"
+    }
+  }
+
+  #expect(classify(viaMemberSyntax) == "timeout")
+  #expect(classify(viaFullyQualified) == "timeout")
+  #expect(classify(inCollection[0]) == "timeout")
+
+  // `throw` / `catch` is the other shape external callers rely on.
+  func thrower() throws { throw MessagesLauncherError.socketTimeout }
+  #expect(throws: MessagesLauncherError.self) { try thrower() }
 }
 
 @Test

--- a/docs/advanced-imcore.md
+++ b/docs/advanced-imcore.md
@@ -65,6 +65,19 @@ make build-dylib   # produces .build/release/imsg-bridge-helper.dylib (arm64e)
 
 `imsg launch` refuses to inject when SIP is enabled. There's no override.
 
+Launch waits up to 15 seconds for the bridge-ready file. On a host with slower
+cold starts, extend that wait for the CLI or its supervisor:
+
+```bash
+IMSG_LAUNCH_READY_TIMEOUT=60 imsg launch --json
+```
+
+The value is a positive number of seconds, capped at 600. Invalid or non-positive
+values use the 15-second default. This also applies to library and bridge calls
+that launch Messages. A timeout still returns an error: Messages may still be
+starting, so check `imsg status` before relaunching. The timeout setting does not
+bypass the SIP or permission checks.
+
 `imsg status` is read-only. It does not auto-launch or auto-inject. Run `imsg launch` first.
 
 To revert: re-enable SIP from Recovery mode (`csrutil enable`), then reboot.


### PR DESCRIPTION
Messages can take longer than 15 seconds to become bridge-ready after a cold start. The existing timeout then reports a launch error with misleading SIP/permission guidance, even when the process becomes ready shortly afterward.

Allow CLI, library, and supervisor callers to set `IMSG_LAUNCH_READY_TIMEOUT` in seconds. Keep the 15-second default, bound positive overrides at 600 seconds, and fall back to the default for invalid values. Recheck readiness at the deadline and explain that Messages may still be starting, with an `imsg status` check before another launch. The public payload-free `MessagesLauncherError.socketTimeout` case and readiness-based success contract are preserved.

The advanced IMCore guide documents the setting, bounds, defaults, and supervisor use. Tests cover timeout resolution, diagnostics, and external-style construction/matching of the public error. Native evidence from the contributor's Mac shows a successful cold start in 18.054 seconds with a 60-second budget and the new diagnostic with a one-second budget. The maintainer proof comment records the final head's validation and remaining host limitations.

Fixes #273. Cross-process launch serialization remains independently handled by #274. Changelog notes are consolidated in the final release-notes PR.
