### PR TITLE
fix: make RPC send tests independent of host bridge availability

### DIFF
--- a/Tests/imsgTests/RPCServerTests.swift
+++ b/Tests/imsgTests/RPCServerTests.swift
@@ -149,7 +149,8 @@ func rpcSendResolvesChatID() async throws {
       captured = options
       return options
     },
-    resolveSentMessage: resolvedSentMessageFixture
+    resolveSentMessage: resolvedSentMessageFixture,
+    isBridgeReady: { false }
   )
 
   let line = #"{"jsonrpc":"2.0","id":"3","method":"send","params":{"chat_id":1,"text":"yo"}}"#
@@ -254,7 +255,8 @@ func rpcSendReturnsSentMessageIdentifiersWhenResolved() async throws {
         attachmentsCount: 0,
         guid: "8DF1B3D7"
       )
-    }
+    },
+    isBridgeReady: { false }
   )
 
   let line = #"{"jsonrpc":"2.0","id":"3b","method":"send","params":{"chat_id":1,"text":"yo"}}"#
@@ -314,7 +316,8 @@ func rpcSendReportsMisroutedChatGhost() async throws {
       }
       return options
     },
-    resolveSentMessage: { _, _, _, _ in nil }
+    resolveSentMessage: { _, _, _, _ in nil },
+    isBridgeReady: { false }
   )
 
   let line = #"{"jsonrpc":"2.0","id":"3d","method":"send","params":{"chat_id":1,"text":"yo"}}"#


### PR DESCRIPTION
Fixes #275.

## Problem

Three `RPCServerTests` cases fail on any macOS host where the bridge helper is actually injected into Messages.app, and pass in CI. That makes `make test` red for anyone developing on a real, working setup, which hides genuine regressions behind expected noise.

- `rpcSendResolvesChatID()`
- `rpcSendReportsMisroutedChatGhost()`
- `rpcSendReturnsSentMessageIdentifiersWhenResolved()`

## Cause

All three construct `RPCServer` without passing `isBridgeReady`, which defaults to `{ true }`. The send handler then takes the bridge branch:

```swift
if let bridgeChatGUID = bridgeChatGUID(...),
  transport != .applescript,
  transport == .bridge || isBridgeReady()
{
```

So the injected `sendMessage` stub is never called.

In CI this is invisible: with no injected helper the bridge invocation throws and the handler falls back to AppleScript, which is exactly what the tests assert. On a machine where the helper *is* injected the bridge call succeeds, and the assertions see `bridge_v2` instead of `applescript`, with `captured` left nil:

```
Expectation failed: (data?["transport"] as? String → "bridge_v2") == "applescript"
Expectation failed: (captured?.chatIdentifier → nil) == "iMessage;+;chat123"
```

The tests are about RPC result shaping, not about which transport happens to be reachable — so the transport should be pinned rather than inherited from host state.

## Change

Pass `isBridgeReady: { false }` at the three call sites. This matches the existing explicit `isBridgeReady: { true }` already used elsewhere in the same file, so the pattern is established.

Test-only. No production behavior changes; the parameter was already injectable.

## Verify

Host: macOS 26, Apple Silicon, SIP disabled, Messages.app running with `imsg-bridge-helper.dylib` injected, `imsg status` reporting `v2_ready: true`.

Before, on this host:

```
✘ rpcSendResolvesChatID() failed
✘ rpcSendReportsMisroutedChatGhost() failed
✘ rpcSendReturnsSentMessageIdentifiersWhenResolved() failed
✘ Test run with 746 tests in 10 suites failed
```

After:

```
✔ Test run with 744 tests in 10 suites passed
```

`make lint`: `Found 15 violations, 0 serious in 249 files`, exit 0 — identical to base `646ea7a`; I diffed the violation sets and this change introduces none.

Disclosure: AI assisted in writing and verifying this change.
