### PR TITLE
test: drain CLI subprocess output before waiting for exit

### DIFF
--- a/Tests/imsgTests/CommandRouterTests.swift
+++ b/Tests/imsgTests/CommandRouterTests.swift
@@ -93,6 +93,12 @@ func runIMsgProcess(
   }
   process.environment = environment
 
+  return try captureProcessOutput(process)
+}
+
+private func captureProcessOutput(_ process: Process) throws -> (
+  status: Int32, output: String, error: String
+) {
   let output = Pipe()
   process.standardOutput = output
   let error = Pipe()
@@ -100,13 +106,30 @@ func runIMsgProcess(
   try process.run()
   output.fileHandleForWriting.closeFile()
   error.fileHandleForWriting.closeFile()
+  let outputReader = TestPipeReader(handle: output.fileHandleForReading)
+  let errorReader = TestPipeReader(handle: error.fileHandleForReading)
+  outputReader.startAndWaitUntilReady()
+  errorReader.startAndWaitUntilReady()
   #expect(!ProcessTimeout.waitUntilExit(process, timeout: 3))
-  let data = output.fileHandleForReading.readDataToEndOfFile()
-  let errorData = error.fileHandleForReading.readDataToEndOfFile()
+  let capturedOutput = outputReader.waitForResult()
+  let capturedError = errorReader.waitForResult()
+  #expect(capturedOutput.errorNumber == nil)
+  #expect(capturedError.errorNumber == nil)
   return (
-    process.terminationStatus, String(decoding: data, as: UTF8.self),
-    String(decoding: errorData, as: UTF8.self)
+    process.terminationStatus, String(decoding: capturedOutput.data, as: UTF8.self),
+    String(decoding: capturedError.data, as: UTF8.self)
   )
+}
+
+@Test
+func processCaptureDrainsBothStreamsBeforeWaitingForExit() throws {
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: "/bin/sh")
+  process.arguments = ["-c", "printf '%131072s' ''; printf '%131072s' '' >&2"]
+  let result = try captureProcessOutput(process)
+  #expect(result.status == 0)
+  #expect(result.output == String(repeating: " ", count: 131_072))
+  #expect(result.error == String(repeating: " ", count: 131_072))
 }
 
 private func imsgExecutableURL() throws -> URL {

--- a/Tests/imsgTests/StdoutCapture.swift
+++ b/Tests/imsgTests/StdoutCapture.swift
@@ -25,19 +25,19 @@ private actor StdoutCaptureLock {
   }
 }
 
-private final class StdoutPipeReader: @unchecked Sendable {
+final class TestPipeReader: @unchecked Sendable {
   struct Result {
     let data: Data
     let errorNumber: Int32?
   }
 
   private let condition = NSCondition()
-  private let readFD: Int32
+  private let handle: FileHandle
   private var isStarted = false
   private var result: Result?
 
-  init(readFD: Int32) {
-    self.readFD = readFD
+  init(handle: FileHandle) {
+    self.handle = handle
   }
 
   func startAndWaitUntilReady() {
@@ -52,7 +52,7 @@ private final class StdoutPipeReader: @unchecked Sendable {
       var errorNumber: Int32?
       var buffer = [UInt8](repeating: 0, count: 64 * 1024)
       while true {
-        let count = read(readFD, &buffer, buffer.count)
+        let count = read(handle.fileDescriptor, &buffer, buffer.count)
         if count > 0 {
           data.append(contentsOf: buffer.prefix(count))
         } else if count == 0 {
@@ -62,7 +62,7 @@ private final class StdoutPipeReader: @unchecked Sendable {
           break
         }
       }
-      close(readFD)
+      try? handle.close()
 
       condition.lock()
       result = Result(data: data, errorNumber: errorNumber)
@@ -92,8 +92,8 @@ enum StdoutCapture {
 
   private static func finish(
     savedStdout: Int32,
-    reader: StdoutPipeReader
-  ) -> (readerResult: StdoutPipeReader.Result, restored: Bool) {
+    reader: TestPipeReader
+  ) -> (readerResult: TestPipeReader.Result, restored: Bool) {
     fflush(nil)
     let restored = dup2(savedStdout, STDOUT_FILENO) >= 0
     if !restored {
@@ -125,7 +125,7 @@ enum StdoutCapture {
       fatalError("dup(STDOUT_FILENO) failed")
     }
 
-    let reader = StdoutPipeReader(readFD: readFD)
+    let reader = TestPipeReader(handle: FileHandle(fileDescriptor: readFD, closeOnDealloc: true))
     reader.startAndWaitUntilReady()
 
     guard dup2(writeFD, STDOUT_FILENO) >= 0 else {


### PR DESCRIPTION
CLI subprocess tests could hang when the child filled stdout or stderr: the helper waited for process exit before reading either pipe. On a Mac whose available pipe capacity had fallen to 512 bytes, even the missing-database diagnostic reproduced the deadlock, including with tests run serially.

Drain both streams concurrently through the existing test pipe reader, then collect them after the child exits. Keep the three-second timeout and all CLI assertions unchanged. FileHandle owns each read descriptor so concurrent capture and cleanup cannot double-close it.

Validation: the new real subprocess regression writes 128 KiB to each stream; it timed out before the repair and passed in 0.059 seconds afterward. The previously failing built-CLI diagnostic test and existing large-stdout capture regression also pass. Full-suite, lint, and review results are recorded in the proof comment.

This is independent of #277: that PR isolates transport choice, while this change fixes output capture. Changelog notes are consolidated in the final release-notes PR.
