### PR TITLE
docs: prepare 0.15.2 unreleased notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+**Highlights:** Safer bridge startup for concurrent callers and slow-starting Macs, with reliable local test runs.
+
+- Serialize Messages bridge launches across processes so waiting callers reuse the ready instance without overlapping startup or shared queue cleanup (#274, thanks @goutamadwant).
+- Let slow hosts extend bridge readiness with `IMSG_LAUNCH_READY_TIMEOUT`, recheck readiness at the deadline, and explain startup timeouts while preserving the 15-second default and public error contract (#276, thanks @omarshahine).
+- Keep RPC send-result tests independent of an injected bridge by explicitly selecting their fixture transport (#277, thanks @omarshahine).
+- Drain CLI test subprocess output while commands run, preventing deadlocks from large output or constrained pipe buffers (#279).
+
 ## 0.15.1 - 2026-09-04
 
 ### Highlights


### PR DESCRIPTION
Prepare the next patch release notes for safer Messages bridge startup and reliable local validation. The Unreleased section is ordered by user impact and carries contributor credit for #274, #276, and #277, plus the subprocess capture repair in #279.

This is the only PR in this batch that edits CHANGELOG.md. Land it after #279, #277, #274, and #276. The audio preparation fix in #278 remains outside these notes until inline Messages playback has inspectable proof on a bridge-enabled Mac.

Dependency recheck found the Swift packages, SwiftLint, and existing Actions pins current. Retain the proven shared release-workflow hotfix pin; today's new release-workflows release needs separate release-pipeline validation. Recommend patch v0.15.2 after the prepared fixes land and main CI passes. No version tag or release has been created.

The proof comment records combined validation and exact-head CI. Version stamping, a dated release section, signed/notarized universal macOS artifacts, Linux packaging, and Homebrew handoff remain gated by release authorization.
