### PR TITLE
fix: give the injected bridge helper a single owner per container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ ifeq ($(shell uname -s),Darwin)
 			-framework Foundation -framework AppKit -framework ImageIO -framework LinkPresentation \
 			"$$source" -o "$$binary" && "$$binary" || exit $$?; \
 	done
+	@clang -fobjc-arc -Wno-arc-performSelector-leaks -Wno-incomplete-implementation \
+		-framework Foundation -framework AppKit -framework ImageIO -framework LinkPresentation \
+		Tests/IMsgHelperTests/BridgeOwnershipHost.m -o .build/helper-tests/BridgeOwnershipHost
 else
 	@echo "Skipping native bridge tests (macOS only)."
 endif

--- a/Sources/IMsgHelper/IMsgInjected.m
+++ b/Sources/IMsgHelper/IMsgInjected.m
@@ -24,6 +24,7 @@
 #import <stdio.h>
 #import <string.h>
 #import <signal.h>
+#import <sys/file.h>
 #import <sys/stat.h>
 #import <dlfcn.h>
 
@@ -120,6 +121,10 @@ imCreateThreadIdentifierFn(void) {
 static NSString *kCommandFile = nil;
 static NSString *kResponseFile = nil;
 static NSString *kLockFile = nil;
+// Single-owner guard. Unlike the ready marker above, nothing ever unlinks
+// this file: flock ownership is tied to the inode, and a fresh inode would let
+// two processes each hold "the" lock.
+static NSString *kOwnerLockFile = nil; // .imsg-bridge-owner.lock
 
 // v2 queue-directory IPC paths.
 static NSString *kRpcDir = nil;       // .imsg-rpc/
@@ -141,6 +146,12 @@ static os_unfair_lock eventsLock = OS_UNFAIR_LOCK_INIT;
 static os_unfair_lock trackedMessageGuidLock = OS_UNFAIR_LOCK_INIT;
 static NSMutableSet<NSString *> *trackedMessageGuids = nil;
 static int lockFd = -1;
+static int ownerLockFd = -1;
+// Set once this process has lost the ownership race and is waiting to take
+// over. Only affects logging: the first stand-down and the eventual takeover
+// are worth a line each, the retries in between are not.
+static BOOL bridgeStandingBy = NO;
+static const NSTimeInterval kOwnershipRetryInterval = 1.0;
 
 static const NSUInteger kEventsRotateBytes = 1 * 1024 * 1024;
 static const NSTimeInterval kV2ClaimMaxAge = 10 * 60;
@@ -153,6 +164,7 @@ static void initFilePaths(void) {
         kCommandFile = [containerPath stringByAppendingPathComponent:@".imsg-command.json"];
         kResponseFile = [containerPath stringByAppendingPathComponent:@".imsg-response.json"];
         kLockFile = [containerPath stringByAppendingPathComponent:@".imsg-bridge-ready"];
+        kOwnerLockFile = [containerPath stringByAppendingPathComponent:@".imsg-bridge-owner.lock"];
         kRpcDir = [containerPath stringByAppendingPathComponent:@".imsg-rpc"];
         kRpcInDir = [kRpcDir stringByAppendingPathComponent:@"in"];
         kRpcOutDir = [kRpcDir stringByAppendingPathComponent:@"out"];
@@ -6948,7 +6960,92 @@ static void startV2InboxWatcher(void) {
     NSLog(@"[imsg-bridge v2] Inbox watcher started");
 }
 
+#pragma mark - Bridge Ownership
+
+/// Exactly one injected Messages.app per container may service the bridge.
+/// The launcher serializes its own launches, but a second injected instance can
+/// still arrive another way: a manual launch with DYLD_INSERT_LIBRARIES set, a
+/// crash-restart supervisor, or a launcher that predates the launch lock. Two
+/// helpers then both clear the legacy IPC files, overwrite each other's pid in
+/// the ready marker, both claim from the same v2 inbox, and whichever exits
+/// first deletes the survivor's ready marker.
+///
+/// Ownership is a kernel flock on a dedicated file, so it dies with the process
+/// and a crashed owner never wedges the next one. On anything but Acquired,
+/// `failure` says why and shared state is left untouched.
+typedef NS_ENUM(NSInteger, BridgeOwnership) {
+    BridgeOwnershipAcquired,
+    /// A live instance holds the lock. Worth retrying: it releases on exit.
+    BridgeOwnershipHeldElsewhere,
+    /// The lock path is unusable (symlink, wrong owner, extra links, I/O error).
+    /// Retrying cannot help.
+    BridgeOwnershipUnavailable,
+};
+
+static BridgeOwnership acquireBridgeOwnership(NSString **failure) {
+    if (ownerLockFd >= 0) return BridgeOwnershipAcquired;
+
+    if (pathHasSymlinkComponent(kOwnerLockFile)) {
+        if (failure) *failure = [NSString stringWithFormat:
+            @"owner lock path traverses a symlink: %@", kOwnerLockFile];
+        return BridgeOwnershipUnavailable;
+    }
+
+    int fd = open(kOwnerLockFile.UTF8String, O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, 0600);
+    if (fd < 0) {
+        if (failure) *failure = [NSString stringWithFormat:
+            @"could not open owner lock %@: %s", kOwnerLockFile, strerror(errno)];
+        return BridgeOwnershipUnavailable;
+    }
+
+    struct stat info;
+    if (fstat(fd, &info) != 0 || info.st_uid != geteuid() || !S_ISREG(info.st_mode) ||
+        info.st_nlink != 1 || (info.st_mode & 077) != 0) {
+        close(fd);
+        if (failure) *failure = [NSString stringWithFormat:
+            @"owner lock must be an owner-only regular file: %@", kOwnerLockFile];
+        return BridgeOwnershipUnavailable;
+    }
+
+    if (flock(fd, LOCK_EX | LOCK_NB) != 0) {
+        int lockErrno = errno;
+        pid_t owner = 0;
+        if (lockErrno == EWOULDBLOCK) {
+            char buf[32] = {0};
+            ssize_t n = pread(fd, buf, sizeof(buf) - 1, 0);
+            if (n > 0) owner = (pid_t)strtol(buf, NULL, 10);
+        }
+        close(fd);
+        if (failure) {
+            *failure = owner > 0
+                ? [NSString stringWithFormat:
+                    @"another injected instance (pid %d) already owns the bridge", (int)owner]
+                : [NSString stringWithFormat:
+                    @"could not acquire owner lock %@: %s", kOwnerLockFile, strerror(lockErrno)];
+        }
+        return lockErrno == EWOULDBLOCK ? BridgeOwnershipHeldElsewhere
+                                        : BridgeOwnershipUnavailable;
+    }
+
+    // Diagnostics only: the flock is the ownership, the pid is for humans.
+    NSString *pidStr = [NSString stringWithFormat:@"%d", getpid()];
+    if (ftruncate(fd, 0) == 0) {
+        pwrite(fd, pidStr.UTF8String, pidStr.length, 0);
+    }
+    ownerLockFd = fd;
+    return BridgeOwnershipAcquired;
+}
+
+static void releaseBridgeOwnership(void) {
+    if (ownerLockFd < 0) return;
+    flock(ownerLockFd, LOCK_UN);
+    close(ownerLockFd);
+    ownerLockFd = -1;
+}
+
 #pragma mark - Dylib Entry Point
+
+static void bridgeClaimOwnership(void);
 
 // Bridge bootstrap. Intentionally NOT run from the dylib constructor: macOS 26
 // tightened dyld initializer ordering for platform/system apps, so touching
@@ -6966,13 +7063,60 @@ static void bridgeBootstrap(void) {
                       bundleIdentifier ?: @"(none)");
                 return;
             }
-            bridgeDidBootstrap = YES;
             initFilePaths();
             NSLog(@"[imsg-bridge] Dylib injected into %@",
                   [[NSProcessInfo processInfo] processName]);
             debugLog(@"bootstrap starting in process=%@ pid=%d",
                      [[NSProcessInfo processInfo] processName], getpid());
+            bridgeClaimOwnership();
+        }
+    });
+}
 
+/// Claim the bridge before touching any shared state, then activate. A loser
+/// must not clear IPC files, rewrite the ready marker, claim requests, or (via
+/// injectedCleanup) remove the owner's ready marker on exit. It does not give
+/// up either: the launcher kills the old Messages and spawns the new one, and
+/// if the old owner is still tearing down when we bootstrap, we would otherwise
+/// lose the race once and leave this process alive with no bridge at all. So a
+/// loser stands by and retries; when the owner exits, its flock is released and
+/// the standby takes over without another relaunch.
+static void bridgeActivate(void);
+static void bridgeClaimOwnership(void) {
+    NSString *failure = nil;
+    switch (acquireBridgeOwnership(&failure)) {
+    case BridgeOwnershipAcquired:
+        if (bridgeStandingBy) {
+            bridgeStandingBy = NO;
+            NSLog(@"[imsg-bridge] Previous owner exited; taking over the bridge");
+            debugLog(@"bridge ownership taken over pid=%d", getpid());
+        } else {
+            debugLog(@"bridge ownership acquired pid=%d", getpid());
+        }
+        bridgeDidBootstrap = YES;
+        bridgeActivate();
+        return;
+    case BridgeOwnershipHeldElsewhere:
+        if (!bridgeStandingBy) {
+            bridgeStandingBy = YES;
+            NSLog(@"[imsg-bridge] Standing by: %@", failure);
+            debugLog(@"stand by pid=%d: %@", getpid(), failure);
+        }
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                                     (int64_t)(kOwnershipRetryInterval * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+            bridgeClaimOwnership();
+        });
+        return;
+    case BridgeOwnershipUnavailable:
+        NSLog(@"[imsg-bridge] Bridge disabled: %@", failure);
+        debugLog(@"bridge disabled pid=%d: %@", getpid(), failure);
+        return;
+    }
+}
+
+static void bridgeActivate(void) {
+    @autoreleasepool {
             // Connect to IMDaemon for full IMCore access
             Class daemonClass = NSClassFromString(@"IMDaemonController");
             if (daemonClass) {
@@ -7013,8 +7157,7 @@ static void bridgeBootstrap(void) {
             startV2InboxWatcher();
             registerEventObservers();
             debugLog(@"bootstrap complete");
-        }
-    });
+    }
 }
 
 __attribute__((constructor))
@@ -7053,4 +7196,6 @@ static void injectedCleanup(void) {
 
     initFilePaths();
     [[NSFileManager defaultManager] removeItemAtPath:kLockFile error:nil];
+    // Release last so the ready marker is removed while we still own the bridge.
+    releaseBridgeOwnership();
 }

--- a/Sources/IMsgHelper/IMsgInjected.m
+++ b/Sources/IMsgHelper/IMsgInjected.m
@@ -6711,6 +6711,33 @@ static void processCommandFile(void) {
     }
 }
 
+/// The ready marker tells the launcher and CLI that an injected helper is up.
+/// Only the bridge owner writes it (see acquireBridgeOwnership).
+static void writeReadyMarker(void) {
+    if (lockFd >= 0) {
+        close(lockFd);
+        lockFd = -1;
+    }
+    lockFd = open(kLockFile.UTF8String, O_CREAT | O_WRONLY | O_TRUNC | O_NOFOLLOW, 0644);
+    if (lockFd >= 0) {
+        NSString *pidStr = [NSString stringWithFormat:@"%d", getpid()];
+        write(lockFd, pidStr.UTF8String, pidStr.length);
+    }
+}
+
+/// The launcher removes the ready marker before it spawns a replacement. If
+/// this owner survived that (killall missed it), the replacement stands by and
+/// nobody would ever write a marker again: the launcher times out even though
+/// the bridge is serving. Keep readiness truthful by restoring the marker
+/// while we hold ownership; the standby takes over the moment we exit.
+static void reassertReadyMarker(void) {
+    if (ownerLockFd < 0) return;
+    if (access(kLockFile.UTF8String, F_OK) == 0) return;
+    writeReadyMarker();
+    NSLog(@"[imsg-bridge] Ready marker was removed while owning the bridge; restored it");
+    debugLog(@"ready marker restored pid=%d", getpid());
+}
+
 static void startFileWatcher(void) {
     initFilePaths();
 
@@ -6723,11 +6750,7 @@ static void startFileWatcher(void) {
     [@"" writeToFile:kResponseFile atomically:YES encoding:NSUTF8StringEncoding error:nil];
 
     // Create lock file with PID to indicate we're ready
-    lockFd = open(kLockFile.UTF8String, O_CREAT | O_WRONLY, 0644);
-    if (lockFd >= 0) {
-        NSString *pidStr = [NSString stringWithFormat:@"%d", getpid()];
-        write(lockFd, pidStr.UTF8String, pidStr.length);
-    }
+    writeReadyMarker();
 
     // Poll command file via NSTimer on the main run loop.
     // NSTimer survives reliably in injected dylib contexts (dispatch_source timers
@@ -6951,8 +6974,11 @@ static void startV2InboxWatcher(void) {
     NSLog(@"[imsg-bridge v2] Inbox: %@", kRpcInDir);
     NSLog(@"[imsg-bridge v2] Outbox: %@", kRpcOutDir);
 
+    __block NSUInteger tick = 0;
     NSTimer *timer = [NSTimer timerWithTimeInterval:0.1 repeats:YES block:^(NSTimer *t) {
         scanV2Inbox();
+        // Once a second is plenty: this only matters during a relaunch.
+        if (++tick % 10 == 0) reassertReadyMarker();
     }];
     [[NSRunLoop mainRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
     rpcInboxTimer = timer;

--- a/Tests/IMsgCoreTests/BridgeOwnershipIntegrationTests.swift
+++ b/Tests/IMsgCoreTests/BridgeOwnershipIntegrationTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+
+@testable import IMsgCore
+
+private let bridgeOwnershipHost = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+  .deletingLastPathComponent().deletingLastPathComponent()
+  .appendingPathComponent(".build/helper-tests/BridgeOwnershipHost")
+
+@Test(
+  .enabled(
+    if: FileManager.default.isExecutableFile(atPath: bridgeOwnershipHost.path),
+    "Run make test-helper to build the native host; make test does this automatically."
+  ))
+func bridgeOwnershipServesRequestsAcrossProcessTakeover() async throws {
+  let home = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  try FileManager.default.createDirectory(
+    at: home, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+  var processes: [Process] = []
+  defer {
+    for process in processes where process.isRunning {
+      process.terminate()
+      process.waitUntilExit()
+    }
+    try? FileManager.default.removeItem(at: home)
+  }
+  func startHost() throws -> Process {
+    let process = Process()
+    process.executableURL = bridgeOwnershipHost
+    process.arguments = [home.path]
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+    try process.run()
+    processes.append(process)
+    return process
+  }
+  func contents(_ name: String) -> String {
+    (try? String(contentsOf: home.appendingPathComponent(name), encoding: .utf8)) ?? ""
+  }
+  func waitFor(_ condition: () -> Bool) async throws {
+    let deadline = ContinuousClock.now + .seconds(10)
+    while !condition() {
+      try #require(ContinuousClock.now < deadline, "Helper lifecycle timed out")
+      try await Task.sleep(for: .milliseconds(25))
+    }
+  }
+  func stopHost(_ process: Process) async throws {
+    try Data().write(to: home.appendingPathComponent("stop-\(process.processIdentifier)"))
+    try await waitFor { !process.isRunning }
+    #expect(process.terminationStatus == 0)
+  }
+  let client = IMsgBridgeClient(launcher: MessagesLauncher(containerPath: home.path))
+  func ping() async throws {
+    let response = try await client.invokeWithoutLaunching(action: .ping)
+    #expect(response["pong"] as? Bool == true)
+  }
+  let owner = try startHost()
+  let ownerPID = String(owner.processIdentifier)
+  try await waitFor { contents(".imsg-bridge-ready") == ownerPID }
+  try await ping()
+
+  let standby = try startHost()
+  let standbyPID = String(standby.processIdentifier)
+  try await waitFor { contents(".imsg-bridge.log").contains("stand by pid=\(standbyPID)") }
+  for _ in 0..<10 { try await ping() }
+  #expect(contents(".imsg-bridge-ready") == ownerPID)
+  let claimsBeforeExit = contents(".imsg-bridge.log").components(separatedBy: "\n")
+    .filter { $0.contains("v2 claimed") }
+  #expect(claimsBeforeExit.count == 11)
+  #expect(claimsBeforeExit.allSatisfy { $0.contains("pid=\(ownerPID) ") })
+
+  // Exiting a standby must not remove the live owner's readiness.
+  try await stopHost(standby)
+  #expect(contents(".imsg-bridge-ready") == ownerPID)
+  try await ping()
+  let replacement = try startHost()
+  let replacementPID = String(replacement.processIdentifier)
+  try await waitFor { contents(".imsg-bridge.log").contains("stand by pid=\(replacementPID)") }
+
+  try FileManager.default.removeItem(at: home.appendingPathComponent(".imsg-bridge-ready"))
+  try await waitFor { contents(".imsg-bridge-ready") == ownerPID }
+  try await ping()
+
+  // Kill without destructor cleanup: the kernel must release ownership.
+  #expect(kill(owner.processIdentifier, SIGKILL) == 0)
+  try await waitFor { !owner.isRunning }
+  try await waitFor { contents(".imsg-bridge-ready") == replacementPID }
+  for _ in 0..<10 { try await ping() }
+  let allClaims = contents(".imsg-bridge.log").components(separatedBy: "\n")
+    .filter { $0.contains("v2 claimed") }
+  #expect(allClaims.count == 23)
+  #expect(allClaims.suffix(10).allSatisfy { $0.contains("pid=\(replacementPID) ") })
+  try await stopHost(replacement)
+  #expect(!client.isReady())
+  #expect(
+    FileManager.default.fileExists(
+      atPath: home.appendingPathComponent(".imsg-bridge-owner.lock").path))
+}

--- a/Tests/IMsgHelperTests/BridgeOwnershipHost.m
+++ b/Tests/IMsgHelperTests/BridgeOwnershipHost.m
@@ -1,0 +1,30 @@
+// Separate process hosting the real helper in an isolated container. No private
+// frameworks are loaded; ping exercises the production queue and dispatcher.
+#import <Foundation/Foundation.h>
+#import "../../Sources/IMsgHelper/IMsgInjected.m"
+
+int main(int argc, const char *argv[]) {
+    @autoreleasepool {
+        if (argc != 2) return 2;
+        NSString *home = [NSString stringWithUTF8String:argv[1]];
+        kCommandFile = [home stringByAppendingPathComponent:@".imsg-command.json"];
+        kResponseFile = [home stringByAppendingPathComponent:@".imsg-response.json"];
+        kLockFile = [home stringByAppendingPathComponent:@".imsg-bridge-ready"];
+        kOwnerLockFile = [home stringByAppendingPathComponent:@".imsg-bridge-owner.lock"];
+        kRpcDir = [home stringByAppendingPathComponent:@".imsg-rpc"];
+        kRpcInDir = [kRpcDir stringByAppendingPathComponent:@"in"];
+        kRpcOutDir = [kRpcDir stringByAppendingPathComponent:@"out"];
+        kEventsFile = [home stringByAppendingPathComponent:@".imsg-events.jsonl"];
+        kEventsRotated = [home stringByAppendingPathComponent:@".imsg-events.jsonl.1"];
+        kDebugLogFile = [home stringByAppendingPathComponent:@".imsg-bridge.log"];
+        NSString *stop = [home stringByAppendingPathComponent:
+            [NSString stringWithFormat:@"stop-%d", getpid()]];
+        bridgeClaimOwnership();
+        NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:60];
+        while (![NSFileManager.defaultManager fileExistsAtPath:stop] && deadline.timeIntervalSinceNow > 0) {
+            [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+        }
+        // Normal process exit invokes the real destructor exactly once.
+        return 0;
+    }
+}

--- a/Tests/IMsgHelperTests/BridgeOwnershipTests.m
+++ b/Tests/IMsgHelperTests/BridgeOwnershipTests.m
@@ -1,0 +1,181 @@
+// Exercise the single-owner guard: exactly one injected helper per container may
+// service the bridge queues, a loser must stand down without touching shared
+// state, and the owner's lock must survive the ready marker being removed.
+#import <Foundation/Foundation.h>
+#import <sys/file.h>
+#import <sys/stat.h>
+#import "../../Sources/IMsgHelper/IMsgInjected.m"
+
+static NSUInteger failures;
+static void check(BOOL condition, NSString *message) {
+    if (condition) return;
+    fprintf(stderr, "FAIL: %s\n", message.UTF8String);
+    failures++;
+}
+
+static NSString *contentsOf(NSString *path) {
+    return [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
+}
+
+/// Stand in for a second injected instance: a separate open file description
+/// on the same lock path. flock ownership is per description, so this conflicts
+/// with the helper's descriptor exactly as another process would.
+static int competitorHold(NSString *path, pid_t pretendPID) {
+    int fd = open(path.fileSystemRepresentation, O_CREAT | O_RDWR | O_NOFOLLOW, 0600);
+    check(fd >= 0, @"Competitor opens the owner lock");
+    check(flock(fd, LOCK_EX | LOCK_NB) == 0, @"Competitor takes the owner lock");
+    NSString *pid = [NSString stringWithFormat:@"%d", pretendPID];
+    check(ftruncate(fd, 0) == 0 && pwrite(fd, pid.UTF8String, pid.length, 0) == (ssize_t)pid.length,
+          @"Competitor records its pid");
+    return fd;
+}
+
+static void competitorRelease(int fd) {
+    if (fd < 0) return;
+    flock(fd, LOCK_UN);
+    close(fd);
+}
+
+static BOOL competitorCanLock(NSString *path) {
+    int fd = open(path.fileSystemRepresentation, O_RDWR | O_NOFOLLOW);
+    if (fd < 0) return NO;
+    BOOL locked = flock(fd, LOCK_EX | LOCK_NB) == 0;
+    competitorRelease(fd);
+    return locked;
+}
+
+int main(int argc, const char *argv[]) {
+    @autoreleasepool {
+        NSString *home = [NSTemporaryDirectory() stringByAppendingPathComponent:NSUUID.UUID.UUIDString];
+        NSFileManager *files = NSFileManager.defaultManager;
+        check([files createDirectoryAtPath:home withIntermediateDirectories:YES
+                               attributes:@{NSFilePosixPermissions: @0700} error:nil],
+              @"Create isolated container");
+
+        // Bind every container path to the fixture so nothing touches Messages.
+        kCommandFile = [home stringByAppendingPathComponent:@".imsg-command.json"];
+        kResponseFile = [home stringByAppendingPathComponent:@".imsg-response.json"];
+        kLockFile = [home stringByAppendingPathComponent:@".imsg-bridge-ready"];
+        kOwnerLockFile = [home stringByAppendingPathComponent:@".imsg-bridge-owner.lock"];
+        kRpcDir = [home stringByAppendingPathComponent:@".imsg-rpc"];
+        kRpcInDir = [kRpcDir stringByAppendingPathComponent:@"in"];
+        kRpcOutDir = [kRpcDir stringByAppendingPathComponent:@"out"];
+        kEventsFile = [home stringByAppendingPathComponent:@".imsg-events.jsonl"];
+        kEventsRotated = [home stringByAppendingPathComponent:@".imsg-events.jsonl.1"];
+        kDebugLogFile = [home stringByAppendingPathComponent:@".imsg-bridge.log"];
+
+        // 1. First helper becomes the owner and records its pid.
+        NSString *failure = nil;
+        check(acquireBridgeOwnership(&failure) == BridgeOwnershipAcquired, @"First helper acquires ownership");
+        check(failure == nil, @"Successful acquisition reports no failure");
+        check(ownerLockFd >= 0, @"Owner keeps the lock descriptor open");
+        check([contentsOf(kOwnerLockFile) isEqualToString:[NSString stringWithFormat:@"%d", getpid()]],
+              @"Owner lock records the owner pid");
+        struct stat info;
+        check(stat(kOwnerLockFile.fileSystemRepresentation, &info) == 0 && (info.st_mode & 0777) == 0600,
+              @"Owner lock is owner-only");
+        check(!competitorCanLock(kOwnerLockFile), @"A second instance cannot take the lock while it is held");
+
+        // 2. Release hands the lock over without unlinking it, so the inode stays stable.
+        releaseBridgeOwnership();
+        check(ownerLockFd == -1, @"Release closes the descriptor");
+        check([files fileExistsAtPath:kOwnerLockFile], @"Release leaves the lock file in place");
+        check(competitorCanLock(kOwnerLockFile), @"A second instance can take the lock after release");
+
+        // 3. Second helper: another instance owns the bridge. Stand down, and
+        //    leave the survivor's ready marker and lock contents untouched.
+        check([@"4242" writeToFile:kLockFile atomically:NO encoding:NSUTF8StringEncoding error:nil],
+              @"Seed the survivor's ready marker");
+        int competitor = competitorHold(kOwnerLockFile, 4242);
+        failure = nil;
+        check(acquireBridgeOwnership(&failure) == BridgeOwnershipHeldElsewhere,
+              @"Second helper sees the lock held by a live instance");
+        check(ownerLockFd == -1, @"Standing down keeps no descriptor");
+        check([failure containsString:@"4242"], @"Stand-down names the owning pid");
+        check([contentsOf(kOwnerLockFile) isEqualToString:@"4242"], @"Standing down leaves the owner's pid");
+        check([contentsOf(kLockFile) isEqualToString:@"4242"], @"Standing down leaves the ready marker");
+
+        // 4. A stood-down helper never bootstrapped, so its destructor must not
+        //    remove the owner's ready marker.
+        bridgeDidBootstrap = NO;
+        injectedCleanup();
+        check([contentsOf(kLockFile) isEqualToString:@"4242"], @"Loser cleanup leaves the ready marker");
+        check([files fileExistsAtPath:kOwnerLockFile], @"Loser cleanup leaves the owner lock");
+        competitorRelease(competitor);
+
+        // 5. The owner's cleanup removes its own ready marker and releases the
+        //    lock, but keeps the lock file so the next owner locks the same inode.
+        check(acquireBridgeOwnership(&failure) == BridgeOwnershipAcquired,
+              @"Helper re-acquires after the other instance exits");
+        bridgeDidBootstrap = YES;
+        check([[NSString stringWithFormat:@"%d", getpid()] writeToFile:kLockFile atomically:NO
+                                                              encoding:NSUTF8StringEncoding error:nil],
+              @"Owner writes its ready marker");
+        injectedCleanup();
+        check(![files fileExistsAtPath:kLockFile], @"Owner cleanup removes its ready marker");
+        check(ownerLockFd == -1, @"Owner cleanup releases the lock");
+        check([files fileExistsAtPath:kOwnerLockFile], @"Owner cleanup keeps the lock file");
+        check(competitorCanLock(kOwnerLockFile), @"The next instance can take the lock after owner cleanup");
+        bridgeDidBootstrap = NO;
+
+        // 6. Tampered lock paths are refused rather than trusted.
+        check([files removeItemAtPath:kOwnerLockFile error:nil], @"Remove lock for the symlink case");
+        NSString *target = [home stringByAppendingPathComponent:@"elsewhere"];
+        check([@"" writeToFile:target atomically:NO encoding:NSUTF8StringEncoding error:nil],
+              @"Create symlink target");
+        check(symlink(target.fileSystemRepresentation, kOwnerLockFile.fileSystemRepresentation) == 0,
+              @"Plant a symlink at the lock path");
+        failure = nil;
+        check(acquireBridgeOwnership(&failure) == BridgeOwnershipUnavailable, @"A symlinked lock path is refused");
+        check(ownerLockFd == -1 && failure.length > 0, @"Symlink refusal reports why");
+        check([files removeItemAtPath:kOwnerLockFile error:nil], @"Remove symlink");
+
+        check(acquireBridgeOwnership(&failure) == BridgeOwnershipAcquired, @"Re-create a regular lock file");
+        releaseBridgeOwnership();
+        NSString *hardlink = [home stringByAppendingPathComponent:@"hardlink"];
+        check(link(kOwnerLockFile.fileSystemRepresentation, hardlink.fileSystemRepresentation) == 0,
+              @"Plant a hard link to the lock");
+        failure = nil;
+        check(acquireBridgeOwnership(&failure) == BridgeOwnershipUnavailable,
+              @"A multiply linked lock file is refused");
+        check(ownerLockFd == -1, @"Hard-link refusal keeps no descriptor");
+        check([files removeItemAtPath:hardlink error:nil], @"Remove hard link");
+        check(acquireBridgeOwnership(&failure) == BridgeOwnershipAcquired,
+              @"Lock works again once the extra link is gone");
+        releaseBridgeOwnership();
+
+        // 7. Real claim path: a helper that loses the race stands by without
+        //    touching shared state, then takes over once the owner exits.
+        check([@"4242" writeToFile:kLockFile atomically:NO encoding:NSUTF8StringEncoding error:nil],
+              @"Seed the owner's ready marker again");
+        competitor = competitorHold(kOwnerLockFile, 4242);
+        bridgeClaimOwnership();
+        [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.3]];
+        check(!bridgeDidBootstrap, @"Standby has not bootstrapped");
+        check(bridgeStandingBy, @"Loser is standing by");
+        check(rpcInboxTimer == nil, @"Standby runs no inbox watcher");
+        check([contentsOf(kLockFile) isEqualToString:@"4242"], @"Standby leaves the owner's ready marker");
+        check(![files fileExistsAtPath:kRpcInDir], @"Standby creates no queue directories");
+
+        competitorRelease(competitor);
+        [[NSRunLoop mainRunLoop] runUntilDate:
+            [NSDate dateWithTimeIntervalSinceNow:kOwnershipRetryInterval + 0.5]];
+        check(bridgeDidBootstrap, @"Standby takes over after the owner exits");
+        check(!bridgeStandingBy, @"Takeover clears the standby flag");
+        check(ownerLockFd >= 0, @"Takeover holds the owner lock");
+        check(rpcInboxTimer != nil, @"Takeover starts the inbox watcher");
+        check([contentsOf(kLockFile) isEqualToString:[NSString stringWithFormat:@"%d", getpid()]],
+              @"Takeover writes its own ready marker");
+        check([files fileExistsAtPath:kRpcInDir], @"Takeover provisions the queue directories");
+        injectedCleanup();
+        check(![files fileExistsAtPath:kLockFile] && ownerLockFd == -1, @"Cleanup after takeover releases everything");
+
+        [files removeItemAtPath:home error:nil];
+        if (failures) {
+            fprintf(stderr, "%lu bridge ownership check(s) failed\n", (unsigned long)failures);
+            return 1;
+        }
+        printf("bridge ownership tests passed\n");
+        return 0;
+    }
+}

--- a/Tests/IMsgHelperTests/BridgeOwnershipTests.m
+++ b/Tests/IMsgHelperTests/BridgeOwnershipTests.m
@@ -167,6 +167,14 @@ int main(int argc, const char *argv[]) {
         check([contentsOf(kLockFile) isEqualToString:[NSString stringWithFormat:@"%d", getpid()]],
               @"Takeover writes its own ready marker");
         check([files fileExistsAtPath:kRpcInDir], @"Takeover provisions the queue directories");
+
+        // 8. A launcher that missed this owner on kill deletes the ready marker
+        //    before spawning a standby. The owner restores it so the launcher
+        //    sees a truthful readiness state instead of timing out.
+        check([files removeItemAtPath:kLockFile error:nil], @"Launcher removes the ready marker");
+        [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.5]];
+        check([contentsOf(kLockFile) isEqualToString:[NSString stringWithFormat:@"%d", getpid()]],
+              @"Owner restores its ready marker within a second");
         injectedCleanup();
         check(![files fileExistsAtPath:kLockFile] && ownerLockFd == -1, @"Cleanup after takeover releases everything");
 

--- a/Tests/imsgTests/BridgeCommandRegistrationTests.swift
+++ b/Tests/imsgTests/BridgeCommandRegistrationTests.swift
@@ -405,9 +405,14 @@ func injectedHelperConstructorOnlySchedulesDelayedBootstrap() throws {
   let source = stripObjectiveCComments(try String(contentsOf: helper, encoding: .utf8))
   let constructorBody = try #require(functionBody(named: "injectedInit", in: source))
   let bootstrapBody = try #require(functionBody(named: "bridgeBootstrap", in: source))
+  let claimBody = try #require(functionBody(named: "bridgeClaimOwnership", in: source))
+  let activateBody = try #require(functionBody(named: "bridgeActivate", in: source))
   let cleanupBody = try #require(functionBody(named: "injectedCleanup", in: source))
   let bundleGuard = try #require(bootstrapBody.range(of: "com.apple.MobileSMS"))
   let initializePaths = try #require(bootstrapBody.range(of: "initFilePaths()"))
+  let acquireOwnership = try #require(claimBody.range(of: "acquireBridgeOwnership("))
+  let markBootstrapped = try #require(claimBody.range(of: "bridgeDidBootstrap = YES"))
+  let activate = try #require(claimBody.range(of: "bridgeActivate();"))
 
   #expect(constructorBody.contains("dispatch_after"))
   #expect(constructorBody.contains("dispatch_async"))
@@ -422,12 +427,26 @@ func injectedHelperConstructorOnlySchedulesDelayedBootstrap() throws {
   #expect(bootstrapBody.contains("dispatch_once"))
   #expect(bootstrapBody.contains("@autoreleasepool"))
   #expect(bundleGuard.lowerBound < initializePaths.lowerBound)
-  #expect(bootstrapBody.contains("bridgeDidBootstrap = YES"))
-  #expect(bootstrapBody.contains("connectToDaemon"))
-  #expect(bootstrapBody.contains("startFileWatcher()"))
-  #expect(bootstrapBody.contains("startV2InboxWatcher()"))
-  #expect(bootstrapBody.contains("registerEventObservers()"))
+  #expect(bootstrapBody.contains("bridgeClaimOwnership();"))
+  #expect(!bootstrapBody.contains("startFileWatcher"))
+  #expect(!bootstrapBody.contains("startV2InboxWatcher"))
+
+  // Shared bridge state may only be touched by the process that owns the lock:
+  // nothing marks the helper bootstrapped or activates it before ownership.
+  #expect(acquireOwnership.lowerBound < markBootstrapped.lowerBound)
+  #expect(markBootstrapped.lowerBound < activate.lowerBound)
+  #expect(claimBody.contains("BridgeOwnershipHeldElsewhere"))
+  #expect(claimBody.contains("dispatch_after"))
+  #expect(!claimBody.contains("startFileWatcher"))
+  #expect(!claimBody.contains("startV2InboxWatcher"))
+
+  #expect(activateBody.contains("@autoreleasepool"))
+  #expect(activateBody.contains("connectToDaemon"))
+  #expect(activateBody.contains("startFileWatcher()"))
+  #expect(activateBody.contains("startV2InboxWatcher()"))
+  #expect(activateBody.contains("registerEventObservers()"))
   #expect(cleanupBody.contains("if (!bridgeDidBootstrap) return;"))
+  #expect(cleanupBody.contains("releaseBridgeOwnership();"))
 }
 
 private func stripObjectiveCComments(_ source: String) -> String {

--- a/docs/advanced-imcore.md
+++ b/docs/advanced-imcore.md
@@ -65,6 +65,17 @@ make build-dylib   # produces .build/release/imsg-bridge-helper.dylib (arm64e)
 
 `imsg launch` refuses to inject when SIP is enabled. There's no override.
 
+Each container has one active helper. Additional instances using the same updated
+helper wait without changing readiness or consuming requests, then take over
+when the owner exits. The owner also restores a ready marker removed during
+launcher cleanup. The `.imsg-bridge-owner.lock` file is permanent; do not delete it
+while a helper is running.
+
+Older injected helpers do not participate in ownership locking. After upgrading,
+stop the old injected Messages instance with `imsg launch --kill-only` before
+launching the updated helper. A patched helper cannot exclude an older helper
+that is still running.
+
 Launch waits up to 15 seconds for the bridge-ready file. On a host with slower
 cold starts, extend that wait for the CLI or its supervisor:
 


### PR DESCRIPTION
A second injected Messages process could clear the active helper's legacy IPC, overwrite its ready PID, and remove the surviving helper's ready marker when it exited. The launcher lock only serializes launcher calls; it does not establish helper ownership.

This change holds a dedicated kernel lock for the helper's lifetime. Standbys leave shared IPC and readiness alone, retry ownership once per second, and activate after the owner exits. The active owner restores a removed ready marker. The lock file remains in place so ownership always refers to the same inode.

Fixes #283. The reported vanished-response symptom is not independently attributed to duplicate claiming; this change repairs the verified ownership and readiness interference.

Validation includes all four native helper suites, all 754 Swift tests, lint (17 existing warnings, no serious violations), helper compilation, and an independent autoreview. A new regression runs separate helper-host processes against an isolated container and uses the production Swift bridge client. It checks exclusive request claims, standby destructor behavior, readiness restoration, SIGKILL takeover, and graceful final cleanup.

For the before case, separate hosts running the main-branch watcher and cleanup functions reproduced both defects: the second host overwrote the first live host’s ready PID, then removed readiness on exit while the first host remained alive.

A separately compiled, Developer-ID-signed consumer also called the built IMsgCore library against those real helper processes:

```text
fresh startup: real IMsgBridgeClient ping -> pong
two live helper processes: 11/11 requests claimed exclusively by owner
removed readiness marker: restored by owner; ping -> pong
owner SIGKILL: standby takes ownership; 10/10 subsequent requests -> pong
graceful final exit: readiness removed; permanent ownership lock retained
```

The newly built, matching-Developer-ID-signed CLI successfully read one row from the real Messages database; private fields were withheld. These are process-lifecycle and protocol proofs, not Messages injection or delivery tests. SIP remains enabled, no private frameworks were loaded in the isolated hosts, and no messages were sent.

Upgrade boundary: old injected helpers do not acquire this lock. Stop the old injected Messages instance with `imsg launch --kill-only` before launching the updated helper. A patched helper cannot exclude an older helper that remains running. The docs now state that boundary explicitly.

Release notes are prepared in the separate final notes PR to avoid sibling changelog conflicts. Credit: @omarshahine.
