### PR TITLE
docs: prepare bridge ownership patch notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Highlights:** Reliable bridge ownership when multiple injected Messages instances overlap.
+
+- Keep one bridge helper active per Messages container, preserve readiness when a standby exits, and automatically take over after the owner stops (#284, thanks @omarshahine).
+
 ## 0.15.2 - 2026-09-07
 
 **Highlights:** Safer bridge startup for concurrent callers and slow-starting Macs, with reliable local test runs.


### PR DESCRIPTION
Prepare the Unreleased notes for the helper ownership fix in #284, with contributor credit and a user-facing highlight. This is the only prepared PR that edits CHANGELOG.md; merge it after #284.

Recommend patch 0.15.3 after both PRs land and the combined main passes CI. The last release is v0.15.2. #278 remains excluded because its existing maintainer gate requires inspectable Messages inline-playback proof.

Dependency recheck found Commander 0.2.4, SQLite.swift 0.16.0, CSQLite 3.53.3, PhoneNumberKit 5.0.8, SwiftLint 0.65.1, and the pinned Actions versions current. Retain the immutable release-workflow hotfix pin: the v1 tag diverges and lacks eight commits from its history.

This PR changes release notes only. It does not tag, publish, or change the release version. Publication still requires a separate authorized release-preparation step and the signed/notarized macOS plus Linux/Homebrew workflow.
