### PR TITLE
chore: refresh phone metadata and prepare 0.15.4 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+**Highlights:** Native voice messages that play inline in Messages.
+
+- Prepare native voice attachments as CAF/Opus for CLI `--audio` and RPC `send.attachment`, fixing unplayable `00:00` bubbles while preserving original files and ordinary attachment sends (#278, thanks @coletebou).
+- Update PhoneNumberKit to 5.0.9 with phone-number metadata 9.0.39.
+
 ## 0.15.3 - 2026-09-07
 
 **Highlights:** Reliable bridge ownership when multiple injected Messages instances overlap.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b3fa12d78aeadf6d1a1ce8872ebe6ad9c54af75bdfe815307402323a9a1ff769",
+  "originHash" : "1668c8b5e632f8fcc29b6f73e16e39e1311cb6d0eabaee2f2b23575b4781906d",
   "pins" : [
     {
       "identity" : "commander",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/PhoneNumberKit/PhoneNumberKit.git",
       "state" : {
-        "revision" : "cf2f1df6f2fe8b49701f4b43f0e97c7bd113d034",
-        "version" : "5.0.8"
+        "revision" : "15c27dbf811e96b9fe48525389ffe042adb9f8cb",
+        "version" : "5.0.9"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     .package(url: "https://github.com/steipete/Commander.git", from: "0.2.4"),
     .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.16.0"),
     .package(url: "https://github.com/stephencelis/CSQLite", from: "3.50.4"),
-    .package(url: "https://github.com/PhoneNumberKit/PhoneNumberKit.git", from: "5.0.8"),
+    .package(url: "https://github.com/PhoneNumberKit/PhoneNumberKit.git", from: "5.0.9"),
   ],
   targets: {
     var targets: [Target] = [


### PR DESCRIPTION
Phone-number metadata is one release behind. Update PhoneNumberKit from 5.0.8 to 5.0.9 (metadata 9.0.39), keeping the manifest and resolved revision aligned. The upstream release changes only metadata resources; the other Swift and Actions dependencies remain current.

Consolidate the complete 0.15.4 Unreleased notes here, with native inline voice playback as the headline and credit to @coletebou. Merge this PR after #278; it is based independently on main and is the only prepared PR that edits CHANGELOG.md. Version finalization and publication remain separate release steps.
